### PR TITLE
Suppressing asynchronous exceptions to avoid app crashes

### DIFF
--- a/lib/src/page/network_manager.dart
+++ b/lib/src/page/network_manager.dart
@@ -567,12 +567,16 @@ class Response {
   Future get content {
     _contentFuture ??= _bodyLoadedCompleter.future.then((error) async {
       if (error is Exception) throw error;
-      var response = await _networkApi
-          .getResponseBody(network.RequestId(request.requestId));
-      if (response.base64Encoded) {
-        return base64.decode(response.body);
-      } else {
-        return response.body;
+      try {
+        var response = await _networkApi
+            .getResponseBody(network.RequestId(request.requestId));
+        if (response.base64Encoded) {
+          return base64.decode(response.body);
+        } else {
+          return response.body;
+        }
+      } catch (message) {
+        _logger.fine('[Response.content] getResponse error: $message');
       }
     });
     return _contentFuture;


### PR DESCRIPTION
**App crash stackTrace:**
``` dart
#0      NetworkApi.getResponseBody (package:puppeteer/protocol/network.dart:299:18)
<asynchronous suspension>
#1      Response.content.<anonymous closure> (package:puppeteer/src/page/network_manager.dart:573:12)
<asynchronous suspension>
#2      _RootZone.runUnary (dart:async/zone.dart:1379:54)
#3      _FutureListener.handleValue (dart:async/future_impl.dart:137:18)
#4      Future._propagateToListeners.handleValueCallback (dart:async/future_impl.dart:678:45)
#5      Future._propagateToListeners (dart:async/future_impl.dart:707:32)
#6      Future._completeWithValue (dart:async/future_impl.dart:522:5)
#7      Future._asyncComplete.<anonymous closure> (dart:async/future_impl.dart:552:7)
#8      _microtaskLoop (dart:async/schedule_microtask.dart:41:21)
#9      _startMicrotaskLoop (dart:async/schedule_microtask.dart:50:5)
#10     _runPendingImmediateCallback (dart:isolate-patch/isolate_patch.dart:116:13)
#11     _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:173:5)
```