### PR TITLE
Fixes file upload

### DIFF
--- a/lib/src/page/js_handle.dart
+++ b/lib/src/page/js_handle.dart
@@ -1,8 +1,5 @@
-import 'dart:convert';
 import 'dart:io';
 import 'dart:math';
-import 'package:mime/mime.dart';
-import 'package:path/path.dart' as p;
 import '../../protocol/dom.dart';
 import '../../protocol/runtime.dart';
 import '../connection.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,6 @@ dependencies:
   http: '>=0.9.0 <0.13.0'
   logging: ^0.11.3
   meta: ^1.1.1
-  mime: ^0.9.0
   path: '>=1.0.0 <2.0.0'
   petitparser: '>=2.2.0 <4.0.0'
   pool: ^1.4.0


### PR DESCRIPTION
Integrate changes from: https://github.com/puppeteer/puppeteer/commit/532ae573d29063ffd081ed9ee340d71b25320dec

> This PR returns to using `DOM.setFileInputFiles`, but with some additional fixes and checks for events and multiple files.

@kendalsickels-wf It seems puppeteer backed-off from the previous change with uploadFiles
please check out this change to see if its affect your project.