### PR TITLE
add Firefox support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,6 +24,7 @@ jobs:
       - run: pub get
       - run: dartanalyzer --fatal-infos --fatal-warnings .
       - run: dart example/download_chromium.dart
+      - run: dart example/download_firefox.dart
       - name: install required packages
         if: runner.os == 'Linux'
         run: |
@@ -32,6 +33,10 @@ jobs:
           Xvfb -ac :99 -screen 0 1280x1024x16 > /dev/null 2>&1 &
       - run: xvfb-run --auto-servernum pub run test -P ci --platform vm
         if: runner.os == 'Linux'
+      - run: xvfb-run --auto-servernum pub run test -P ci --platform vm
+        if: runner.os == 'Linux'
+        env:
+          PUPPETEER_PRODUCT: firefox
       - run: pub run test -P ci --platform vm
         if: runner.os != 'Linux'
       - run: dart tool/prepare_submit.dart

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,10 @@ jobs:
           Xvfb -ac :99 -screen 0 1280x1024x16 > /dev/null 2>&1 &
       - run: xvfb-run --auto-servernum pub run test -P ci --platform vm
         if: runner.os == 'Linux'
-      - run: xvfb-run --auto-servernum pub run test -P ci --platform vm
+      - run: |
+          rm example/print_to_pdf.dart example/screenshot_element.dart
+          xvfb-run --auto-servernum pub run test -P ci --platform vm
+          git reset --hard HEAD
         if: runner.os == 'Linux'
         env:
           PUPPETEER_PRODUCT: firefox

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,11 +10,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        dart: ['stable']
+        dart: ["stable"]
     runs-on: ${{ matrix.os }}
-#    env:
-#      #In travis/docker we need the --no-sandbox flag in chrome
-#      CHROME_FORCE_NO_SANDBOX: true
+    #    env:
+    #      #In travis/docker we need the --no-sandbox flag in chrome
+    #      CHROME_FORCE_NO_SANDBOX: true
     steps:
       - uses: cedx/setup-dart@v2
         with:
@@ -33,10 +33,7 @@ jobs:
           Xvfb -ac :99 -screen 0 1280x1024x16 > /dev/null 2>&1 &
       - run: xvfb-run --auto-servernum pub run test -P ci --platform vm
         if: runner.os == 'Linux'
-      - run: |
-          rm example/print_to_pdf.dart example/screenshot_element.dart
-          xvfb-run --auto-servernum pub run test -P ci --platform vm
-          git reset --hard HEAD
+      - run: xvfb-run --auto-servernum pub run test -P ci --platform vm
         if: runner.os == 'Linux'
         env:
           PUPPETEER_PRODUCT: firefox

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ void main() async {
   await page.click(allResultsSelector);
 
   // Wait for the results page to load and display the results.
-  const resultsSelector = '.gsc-results .gsc-thumbnail-inside a.gs-title';
+  const resultsSelector = '.gsc-result a.gs-title';
   await page.waitForSelector(resultsSelector);
 
   // Extract the results from the page.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Most things that you can do manually in the browser can be done using Puppeteer!
 
 Download the last revision of chrome and launch it.
 ```dart
+import 'dart:io';
 import 'package:puppeteer/puppeteer.dart';
 
 void main() async {
@@ -47,11 +48,11 @@ void main() async {
   var myPage = await browser.newPage();
 
   // Go to a page and wait to be fully loaded
-  await myPage.goto('https://www.github.com', wait: Until.networkIdle);
+  await myPage.goto('https://www.github.com', wait: Until.domContentLoaded);
 
   // Do something... See other examples
   await myPage.screenshot();
-  await myPage.pdf();
+  await myPage.pdf(output: File('github_my_page.pdf').openWrite());
   await myPage.evaluate('() => document.title');
 
   // Gracefully close the browser's process

--- a/example/block_images.dart
+++ b/example/block_images.dart
@@ -1,7 +1,16 @@
 import 'dart:io';
+import 'package:logging/logging.dart';
 import 'package:puppeteer/puppeteer.dart';
 
 void main() async {
+  final logger = Logger('example.block_images');
+
+  if (isPuppeteerFirefox) {
+    logger.warning('block_images cannot be executed on Firefox.');
+    logger.warning(
+        'Firefox currently does not support intercepting request/response');
+    return;
+  }
   var browser = await puppeteer.launch();
   var page = await browser.newPage();
   await page.setRequestInterception(true);

--- a/example/detect_my_browser.dart
+++ b/example/detect_my_browser.dart
@@ -1,0 +1,36 @@
+import 'dart:io';
+
+import 'package:logging/logging.dart';
+import 'package:puppeteer/puppeteer.dart';
+
+Future<void> main() async {
+  Logger.root.level = Level.ALL;
+  Logger.root.onRecord.listen(print);
+
+  final browser = await puppeteerFirefox.launch(
+    headless: false,
+    executablePath: '/Applications/Firefox Nightly.app/Contents/MacOS/firefox',
+  );
+  final myPage = await browser.newPage();
+
+  // Go to a page and wait to be fully loaded
+  await myPage.goto('https://www.google.com');
+
+  // Do something... See other examples
+  await myPage.click('input[name="q"]');
+  await myPage.keyboard.type('puppeteer');
+
+  await Future.wait([
+    myPage.waitForNavigation(),
+    myPage.keyboard.press(Key.enter),
+  ]);
+
+  await File('_google-puppeteer.png').writeAsBytes(await myPage.screenshot());
+
+  await myPage.goto('https://detectmybrowser.com/');
+
+  await File('_detect-my-browser.png').writeAsBytes(await myPage.screenshot());
+
+  // Gracefully close the browser's process
+  await browser.close();
+}

--- a/example/detect_my_browser.dart
+++ b/example/detect_my_browser.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-
 import 'package:logging/logging.dart';
 import 'package:puppeteer/puppeteer.dart';
 
@@ -7,10 +6,7 @@ Future<void> main() async {
   Logger.root.level = Level.ALL;
   Logger.root.onRecord.listen(print);
 
-  final browser = await puppeteerFirefox.launch(
-    headless: false,
-    executablePath: '/Applications/Firefox Nightly.app/Contents/MacOS/firefox',
-  );
+  final browser = await puppeteerFirefox.launch();
   final myPage = await browser.newPage();
 
   // Go to a page and wait to be fully loaded

--- a/example/download_firefox.dart
+++ b/example/download_firefox.dart
@@ -1,0 +1,8 @@
+import 'package:puppeteer/puppeteer.dart';
+
+Future<void> main() async {
+  final firefoxPath = await downloadFirefox(
+      // Specify the custom location (by default it .local-chromium)
+      cachePath: null);
+  print(firefoxPath.executablePath);
+}

--- a/example/example.dart
+++ b/example/example.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'package:puppeteer/puppeteer.dart';
 
 void main() async {
@@ -8,11 +9,11 @@ void main() async {
   var myPage = await browser.newPage();
 
   // Go to a page and wait to be fully loaded
-  await myPage.goto('https://www.github.com', wait: Until.networkIdle);
+  await myPage.goto('https://www.github.com', wait: Until.domContentLoaded);
 
   // Do something... See other examples
   await myPage.screenshot();
-  await myPage.pdf();
+  await myPage.pdf(output: File('github_my_page.pdf').openWrite());
   await myPage.evaluate('() => document.title');
 
   // Gracefully close the browser's process

--- a/example/incognito.dart
+++ b/example/incognito.dart
@@ -21,9 +21,9 @@ void main() async {
   var incognitoTab1 = await incognitoContext.newPage();
 
   await Future.wait([
-    normalTab1.goto(pageUrl, wait: Until.networkIdle),
-    normalTab2.goto(pageUrl, wait: Until.networkIdle),
-    incognitoTab1.goto(pageUrl, wait: Until.networkIdle),
+    normalTab1.goto(pageUrl),
+    normalTab2.goto(pageUrl),
+    incognitoTab1.goto(pageUrl),
   ]);
 
   await normalTab1.evaluate('window.localStorage.setItem("name", "xavier")');

--- a/example/keyboard.dart
+++ b/example/keyboard.dart
@@ -24,7 +24,12 @@ void main() async {
 
   await page.bringToFront();
 
-  await page.keyboard.type('éèà Hello');
+  if (isPuppeteerFirefox) {
+    // Firefox cannot input 'è' with Input.insertText
+    await page.keyboard.type('Hello World!');
+  } else {
+    await page.keyboard.type('éèà Hello');
+  }
 
   await page.keyboard.down(Key.shift);
   await page.keyboard.press(Key.arrowLeft);

--- a/example/metrics.dart
+++ b/example/metrics.dart
@@ -3,7 +3,7 @@ import 'package:puppeteer/puppeteer.dart';
 void main() async {
   var browser = await puppeteer.launch();
   var page = await browser.newPage();
-  await page.goto('https://www.github.com', wait: Until.networkIdle);
+  await page.goto('https://www.github.com');
 
   var metrics = await page.metrics();
 

--- a/example/search.dart
+++ b/example/search.dart
@@ -16,7 +16,7 @@ void main() async {
   await page.click(allResultsSelector);
 
   // Wait for the results page to load and display the results.
-  const resultsSelector = '.gsc-results .gsc-thumbnail-inside a.gs-title';
+  const resultsSelector = '.gsc-result a.gs-title';
   await page.waitForSelector(resultsSelector);
 
   // Extract the results from the page.

--- a/lib/protocol/browser.dart
+++ b/lib/protocol/browser.dart
@@ -221,7 +221,8 @@ class BrowserContextID {
 
   BrowserContextID(this.value);
 
-  factory BrowserContextID.fromJson(String value) => BrowserContextID(value);
+  factory BrowserContextID.fromJson(dynamic value) =>
+      BrowserContextID(value.toString());
 
   String toJson() => value;
 

--- a/lib/protocol/dom.dart
+++ b/lib/protocol/dom.dart
@@ -63,7 +63,7 @@ class DOMApi {
   Stream<List<NodeId>> get onInlineStyleInvalidated => _client.onEvent
       .where((event) => event.name == 'DOM.inlineStyleInvalidated')
       .map((event) => (event.parameters['nodeIds'] as List)
-          .map((e) => NodeId.fromJson(e as int))
+          .map((e) => NodeId.fromJson(e))
           .toList());
 
   /// Called when a pseudo element is added to an element.
@@ -117,7 +117,7 @@ class DOMApi {
       'targetNodeId': targetNodeId,
       if (insertBeforeNodeId != null) 'insertBeforeNodeId': insertBeforeNodeId,
     });
-    return NodeId.fromJson(result['nodeId'] as int);
+    return NodeId.fromJson(result['nodeId']);
   }
 
   /// Describes node given its id, does not require domain to be enabled. Does not start tracking any
@@ -295,9 +295,7 @@ class DOMApi {
       'computedStyles': [...computedStyles],
       if (pierce != null) 'pierce': pierce,
     });
-    return (result['nodeIds'] as List)
-        .map((e) => NodeId.fromJson(e as int))
-        .toList();
+    return (result['nodeIds'] as List).map((e) => NodeId.fromJson(e)).toList();
   }
 
   /// Returns node id at given location. Depending on whether DOM domain is enabled, nodeId is
@@ -343,7 +341,7 @@ class DOMApi {
     var result = await _client.send('DOM.getRelayoutBoundary', {
       'nodeId': nodeId,
     });
-    return NodeId.fromJson(result['nodeId'] as int);
+    return NodeId.fromJson(result['nodeId']);
   }
 
   /// Returns search results from given `fromIndex` to given `toIndex` from the search with the given
@@ -359,9 +357,7 @@ class DOMApi {
       'fromIndex': fromIndex,
       'toIndex': toIndex,
     });
-    return (result['nodeIds'] as List)
-        .map((e) => NodeId.fromJson(e as int))
-        .toList();
+    return (result['nodeIds'] as List).map((e) => NodeId.fromJson(e)).toList();
   }
 
   /// Hides any highlight.
@@ -397,7 +393,7 @@ class DOMApi {
       'targetNodeId': targetNodeId,
       if (insertBeforeNodeId != null) 'insertBeforeNodeId': insertBeforeNodeId,
     });
-    return NodeId.fromJson(result['nodeId'] as int);
+    return NodeId.fromJson(result['nodeId']);
   }
 
   /// Searches for a given string in the DOM tree. Use `getSearchResults` to access search results or
@@ -421,7 +417,7 @@ class DOMApi {
     var result = await _client.send('DOM.pushNodeByPathToFrontend', {
       'path': path,
     });
-    return NodeId.fromJson(result['nodeId'] as int);
+    return NodeId.fromJson(result['nodeId']);
   }
 
   /// Requests that a batch of nodes is sent to the caller given their backend node ids.
@@ -433,9 +429,7 @@ class DOMApi {
     var result = await _client.send('DOM.pushNodesByBackendIdsToFrontend', {
       'backendNodeIds': [...backendNodeIds],
     });
-    return (result['nodeIds'] as List)
-        .map((e) => NodeId.fromJson(e as int))
-        .toList();
+    return (result['nodeIds'] as List).map((e) => NodeId.fromJson(e)).toList();
   }
 
   /// Executes `querySelector` on a given node.
@@ -447,7 +441,7 @@ class DOMApi {
       'nodeId': nodeId,
       'selector': selector,
     });
-    return NodeId.fromJson(result['nodeId'] as int);
+    return NodeId.fromJson(result['nodeId']);
   }
 
   /// Executes `querySelectorAll` on a given node.
@@ -459,9 +453,7 @@ class DOMApi {
       'nodeId': nodeId,
       'selector': selector,
     });
-    return (result['nodeIds'] as List)
-        .map((e) => NodeId.fromJson(e as int))
-        .toList();
+    return (result['nodeIds'] as List).map((e) => NodeId.fromJson(e)).toList();
   }
 
   /// Re-does the last undone action.
@@ -513,7 +505,7 @@ class DOMApi {
     var result = await _client.send('DOM.requestNode', {
       'objectId': objectId,
     });
-    return NodeId.fromJson(result['nodeId'] as int);
+    return NodeId.fromJson(result['nodeId']);
   }
 
   /// Resolves the JavaScript node object for a given NodeId or BackendNodeId.
@@ -629,7 +621,7 @@ class DOMApi {
       'nodeId': nodeId,
       'name': name,
     });
-    return NodeId.fromJson(result['nodeId'] as int);
+    return NodeId.fromJson(result['nodeId']);
   }
 
   /// Sets node value for a node with given id.
@@ -681,7 +673,7 @@ class AttributeModifiedEvent {
 
   factory AttributeModifiedEvent.fromJson(Map<String, dynamic> json) {
     return AttributeModifiedEvent(
-      nodeId: NodeId.fromJson(json['nodeId'] as int),
+      nodeId: NodeId.fromJson(json['nodeId']),
       name: json['name'] as String,
       value: json['value'] as String,
     );
@@ -699,7 +691,7 @@ class AttributeRemovedEvent {
 
   factory AttributeRemovedEvent.fromJson(Map<String, dynamic> json) {
     return AttributeRemovedEvent(
-      nodeId: NodeId.fromJson(json['nodeId'] as int),
+      nodeId: NodeId.fromJson(json['nodeId']),
       name: json['name'] as String,
     );
   }
@@ -717,7 +709,7 @@ class CharacterDataModifiedEvent {
 
   factory CharacterDataModifiedEvent.fromJson(Map<String, dynamic> json) {
     return CharacterDataModifiedEvent(
-      nodeId: NodeId.fromJson(json['nodeId'] as int),
+      nodeId: NodeId.fromJson(json['nodeId']),
       characterData: json['characterData'] as String,
     );
   }
@@ -735,7 +727,7 @@ class ChildNodeCountUpdatedEvent {
 
   factory ChildNodeCountUpdatedEvent.fromJson(Map<String, dynamic> json) {
     return ChildNodeCountUpdatedEvent(
-      nodeId: NodeId.fromJson(json['nodeId'] as int),
+      nodeId: NodeId.fromJson(json['nodeId']),
       childNodeCount: json['childNodeCount'] as int,
     );
   }
@@ -758,8 +750,8 @@ class ChildNodeInsertedEvent {
 
   factory ChildNodeInsertedEvent.fromJson(Map<String, dynamic> json) {
     return ChildNodeInsertedEvent(
-      parentNodeId: NodeId.fromJson(json['parentNodeId'] as int),
-      previousNodeId: NodeId.fromJson(json['previousNodeId'] as int),
+      parentNodeId: NodeId.fromJson(json['parentNodeId']),
+      previousNodeId: NodeId.fromJson(json['previousNodeId']),
       node: Node.fromJson(json['node'] as Map<String, dynamic>),
     );
   }
@@ -776,8 +768,8 @@ class ChildNodeRemovedEvent {
 
   factory ChildNodeRemovedEvent.fromJson(Map<String, dynamic> json) {
     return ChildNodeRemovedEvent(
-      parentNodeId: NodeId.fromJson(json['parentNodeId'] as int),
-      nodeId: NodeId.fromJson(json['nodeId'] as int),
+      parentNodeId: NodeId.fromJson(json['parentNodeId']),
+      nodeId: NodeId.fromJson(json['nodeId']),
     );
   }
 }
@@ -794,7 +786,7 @@ class DistributedNodesUpdatedEvent {
 
   factory DistributedNodesUpdatedEvent.fromJson(Map<String, dynamic> json) {
     return DistributedNodesUpdatedEvent(
-      insertionPointId: NodeId.fromJson(json['insertionPointId'] as int),
+      insertionPointId: NodeId.fromJson(json['insertionPointId']),
       distributedNodes: (json['distributedNodes'] as List)
           .map((e) => BackendNode.fromJson(e as Map<String, dynamic>))
           .toList(),
@@ -814,7 +806,7 @@ class PseudoElementAddedEvent {
 
   factory PseudoElementAddedEvent.fromJson(Map<String, dynamic> json) {
     return PseudoElementAddedEvent(
-      parentId: NodeId.fromJson(json['parentId'] as int),
+      parentId: NodeId.fromJson(json['parentId']),
       pseudoElement:
           Node.fromJson(json['pseudoElement'] as Map<String, dynamic>),
     );
@@ -833,8 +825,8 @@ class PseudoElementRemovedEvent {
 
   factory PseudoElementRemovedEvent.fromJson(Map<String, dynamic> json) {
     return PseudoElementRemovedEvent(
-      parentId: NodeId.fromJson(json['parentId'] as int),
-      pseudoElementId: NodeId.fromJson(json['pseudoElementId'] as int),
+      parentId: NodeId.fromJson(json['parentId']),
+      pseudoElementId: NodeId.fromJson(json['pseudoElementId']),
     );
   }
 }
@@ -850,7 +842,7 @@ class SetChildNodesEvent {
 
   factory SetChildNodesEvent.fromJson(Map<String, dynamic> json) {
     return SetChildNodesEvent(
-      parentId: NodeId.fromJson(json['parentId'] as int),
+      parentId: NodeId.fromJson(json['parentId']),
       nodes: (json['nodes'] as List)
           .map((e) => Node.fromJson(e as Map<String, dynamic>))
           .toList(),
@@ -869,8 +861,8 @@ class ShadowRootPoppedEvent {
 
   factory ShadowRootPoppedEvent.fromJson(Map<String, dynamic> json) {
     return ShadowRootPoppedEvent(
-      hostId: NodeId.fromJson(json['hostId'] as int),
-      rootId: NodeId.fromJson(json['rootId'] as int),
+      hostId: NodeId.fromJson(json['hostId']),
+      rootId: NodeId.fromJson(json['rootId']),
     );
   }
 }
@@ -886,7 +878,7 @@ class ShadowRootPushedEvent {
 
   factory ShadowRootPushedEvent.fromJson(Map<String, dynamic> json) {
     return ShadowRootPushedEvent(
-      hostId: NodeId.fromJson(json['hostId'] as int),
+      hostId: NodeId.fromJson(json['hostId']),
       root: Node.fromJson(json['root'] as Map<String, dynamic>),
     );
   }
@@ -907,11 +899,10 @@ class GetNodeForLocationResult {
 
   factory GetNodeForLocationResult.fromJson(Map<String, dynamic> json) {
     return GetNodeForLocationResult(
-      backendNodeId: BackendNodeId.fromJson(json['backendNodeId'] as int),
+      backendNodeId: BackendNodeId.fromJson(json['backendNodeId']),
       frameId: page.FrameId.fromJson(json['frameId'] as String),
-      nodeId: json.containsKey('nodeId')
-          ? NodeId.fromJson(json['nodeId'] as int)
-          : null,
+      nodeId:
+          json.containsKey('nodeId') ? NodeId.fromJson(json['nodeId']) : null,
     );
   }
 }
@@ -944,23 +935,22 @@ class GetFrameOwnerResult {
 
   factory GetFrameOwnerResult.fromJson(Map<String, dynamic> json) {
     return GetFrameOwnerResult(
-      backendNodeId: BackendNodeId.fromJson(json['backendNodeId'] as int),
-      nodeId: json.containsKey('nodeId')
-          ? NodeId.fromJson(json['nodeId'] as int)
-          : null,
+      backendNodeId: BackendNodeId.fromJson(json['backendNodeId']),
+      nodeId:
+          json.containsKey('nodeId') ? NodeId.fromJson(json['nodeId']) : null,
     );
   }
 }
 
 /// Unique DOM node identifier.
 class NodeId {
-  final int value;
+  final dynamic value;
 
   NodeId(this.value);
 
-  factory NodeId.fromJson(int value) => NodeId(value);
+  factory NodeId.fromJson(dynamic value) => NodeId(value);
 
-  int toJson() => value;
+  dynamic toJson() => value;
 
   @override
   bool operator ==(other) =>
@@ -976,13 +966,13 @@ class NodeId {
 /// Unique DOM node identifier used to reference a node that may not have been pushed to the
 /// front-end.
 class BackendNodeId {
-  final int value;
+  final dynamic value;
 
   BackendNodeId(this.value);
 
-  factory BackendNodeId.fromJson(int value) => BackendNodeId(value);
+  factory BackendNodeId.fromJson(dynamic value) => BackendNodeId(value);
 
-  int toJson() => value;
+  dynamic toJson() => value;
 
   @override
   bool operator ==(other) =>
@@ -1014,7 +1004,7 @@ class BackendNode {
     return BackendNode(
       nodeType: json['nodeType'] as int,
       nodeName: json['nodeName'] as String,
-      backendNodeId: BackendNodeId.fromJson(json['backendNodeId'] as int),
+      backendNodeId: BackendNodeId.fromJson(json['backendNodeId']),
     );
   }
 
@@ -1234,11 +1224,11 @@ class Node {
 
   factory Node.fromJson(Map<String, dynamic> json) {
     return Node(
-      nodeId: NodeId.fromJson(json['nodeId'] as int),
+      nodeId: NodeId.fromJson(json['nodeId']),
       parentId: json.containsKey('parentId')
-          ? NodeId.fromJson(json['parentId'] as int)
+          ? NodeId.fromJson(json['parentId'])
           : null,
-      backendNodeId: BackendNodeId.fromJson(json['backendNodeId'] as int),
+      backendNodeId: BackendNodeId.fromJson(json['backendNodeId']),
       nodeType: json['nodeType'] as int,
       nodeName: json['nodeName'] as String,
       localName: json['localName'] as String,

--- a/lib/protocol/log.dart
+++ b/lib/protocol/log.dart
@@ -94,7 +94,9 @@ class LogEntry {
     return LogEntry(
       source: LogEntrySource.fromJson(json['source'] as String),
       level: LogEntryLevel.fromJson(json['level'] as String),
-      text: json['text'] as String,
+      text: (json['text'] is List)
+          ? (json['text'] as List).join('\n')
+          : json['text'] as String,
       timestamp: runtime.Timestamp.fromJson(json['timestamp'] as num),
       url: json.containsKey('url') ? json['url'] as String : null,
       lineNumber:

--- a/lib/protocol/network.dart
+++ b/lib/protocol/network.dart
@@ -803,7 +803,9 @@ class RequestWillBeSentEvent {
       request: RequestData.fromJson(json['request'] as Map<String, dynamic>),
       timestamp: MonotonicTime.fromJson(json['timestamp'] as num),
       wallTime: TimeSinceEpoch.fromJson(json['wallTime'] as num),
-      initiator: Initiator.fromJson(json['initiator'] as Map<String, dynamic>),
+      initiator: json.containsKey('initiator')
+          ? Initiator.fromJson(json['initiator'] as Map<String, dynamic>)
+          : null,
       redirectResponse: json.containsKey('redirectResponse')
           ? ResponseData.fromJson(
               json['redirectResponse'] as Map<String, dynamic>)
@@ -1963,6 +1965,9 @@ class SecurityDetails {
       @required this.certificateTransparencyCompliance});
 
   factory SecurityDetails.fromJson(Map<String, dynamic> json) {
+    // Firefox doesn't implement this payload.
+    if (json == null) return null;
+
     return SecurityDetails(
       protocol: json['protocol'] as String,
       keyExchange: json['keyExchange'] as String,
@@ -1974,15 +1979,19 @@ class SecurityDetails {
       certificateId:
           security.CertificateId.fromJson(json['certificateId'] as int),
       subjectName: json['subjectName'] as String,
-      sanList: (json['sanList'] as List).map((e) => e as String).toList(),
+      sanList: json.containsKey('sanList')
+          ? (json['sanList'] as List).map((e) => e as String).toList()
+          : null,
       issuer: json['issuer'] as String,
       validFrom: TimeSinceEpoch.fromJson(json['validFrom'] as num),
       validTo: TimeSinceEpoch.fromJson(json['validTo'] as num),
-      signedCertificateTimestampList: (json['signedCertificateTimestampList']
-              as List)
-          .map((e) =>
-              SignedCertificateTimestamp.fromJson(e as Map<String, dynamic>))
-          .toList(),
+      signedCertificateTimestampList:
+          json.containsKey('signedCertificateTimestampList')
+              ? (json['signedCertificateTimestampList'] as List)
+                  .map((e) => SignedCertificateTimestamp.fromJson(
+                      e as Map<String, dynamic>))
+                  .toList()
+              : null,
       certificateTransparencyCompliance:
           CertificateTransparencyCompliance.fromJson(
               json['certificateTransparencyCompliance'] as String),

--- a/lib/protocol/page.dart
+++ b/lib/protocol/page.dart
@@ -1922,6 +1922,9 @@ class VisualViewport {
       this.zoom});
 
   factory VisualViewport.fromJson(Map<String, dynamic> json) {
+    // Firefox doesn't implement this payload.
+    if (json == null) return null;
+
     return VisualViewport(
       offsetX: json['offsetX'] as num,
       offsetY: json['offsetY'] as num,

--- a/lib/protocol/runtime.dart
+++ b/lib/protocol/runtime.dart
@@ -771,6 +771,9 @@ class RemoteObject {
       this.customPreview});
 
   factory RemoteObject.fromJson(Map<String, dynamic> json) {
+    // Firefox sometimes doesn't implement this payload.
+    if (json == null) return null;
+
     return RemoteObject(
       type: RemoteObjectType.fromJson(json['type'] as String),
       subtype: json.containsKey('subtype')

--- a/lib/protocol/runtime.dart
+++ b/lib/protocol/runtime.dart
@@ -1709,13 +1709,18 @@ class StackTraceData {
       this.parentId});
 
   factory StackTraceData.fromJson(Map<String, dynamic> json) {
+    // Firefox sometimes doesn't implement this payload.
+    if (json == null) return null;
+
     return StackTraceData(
       description: json.containsKey('description')
           ? json['description'] as String
           : null,
-      callFrames: (json['callFrames'] as List)
-          .map((e) => CallFrame.fromJson(e as Map<String, dynamic>))
-          .toList(),
+      callFrames: json.containsKey('callFrames')
+          ? (json['callFrames'] as List)
+              .map((e) => CallFrame.fromJson(e as Map<String, dynamic>))
+              .toList()
+          : null,
       parent: json.containsKey('parent')
           ? StackTraceData.fromJson(json['parent'] as Map<String, dynamic>)
           : null,

--- a/lib/protocol/target.dart
+++ b/lib/protocol/target.dart
@@ -86,7 +86,8 @@ class TargetApi {
     var result = await _client.send('Target.closeTarget', {
       'targetId': targetId,
     });
-    return result['success'] as bool;
+    // Firefox returns null.
+    return result == null || result['success'] as bool;
   }
 
   /// Inject object to the target's main frame that provides a communication
@@ -121,8 +122,7 @@ class TargetApi {
       if (proxyServer != null) 'proxyServer': proxyServer,
       if (proxyBypassList != null) 'proxyBypassList': proxyBypassList,
     });
-    return browser.BrowserContextID.fromJson(
-        result['browserContextId'] as String);
+    return browser.BrowserContextID.fromJson(result['browserContextId']);
   }
 
   /// Returns all browser contexts created with `Target.createBrowserContext` method.
@@ -130,7 +130,7 @@ class TargetApi {
   Future<List<browser.BrowserContextID>> getBrowserContexts() async {
     var result = await _client.send('Target.getBrowserContexts');
     return (result['browserContextIds'] as List)
-        .map((e) => browser.BrowserContextID.fromJson(e as String))
+        .map((e) => browser.BrowserContextID.fromJson(e))
         .toList();
   }
 
@@ -418,8 +418,7 @@ class TargetInfo {
           ? page.FrameId.fromJson(json['openerFrameId'] as String)
           : null,
       browserContextId: json.containsKey('browserContextId')
-          ? browser.BrowserContextID.fromJson(
-              json['browserContextId'] as String)
+          ? browser.BrowserContextID.fromJson(json['browserContextId'])
           : null,
     );
   }

--- a/lib/puppeteer.dart
+++ b/lib/puppeteer.dart
@@ -4,7 +4,7 @@ export 'protocol/input.dart' show MouseButton;
 export 'protocol/network.dart' show CookieParam, ResourceType, ErrorReason;
 export 'src/browser.dart' show Browser, BrowserContext, PermissionType;
 export 'src/connection.dart' show ServerException, TargetClosedException;
-export 'src/downloader.dart' show downloadChrome, RevisionInfo;
+export 'src/downloader.dart' show downloadChrome, downloadFirefox, RevisionInfo;
 export 'src/page/accessibility.dart' show Accessibility, AXNode;
 export 'src/page/coverage.dart' show Coverage, CoverageEntry, Range;
 export 'src/page/dialog.dart' show Dialog, DialogType;

--- a/lib/puppeteer.dart
+++ b/lib/puppeteer.dart
@@ -32,5 +32,6 @@ export 'src/page/page.dart'
         MediaFeature;
 export 'src/page/tracing.dart' show Tracing;
 export 'src/puppeteer.dart' show puppeteer, Puppeteer;
-export 'src/puppeteer_firefox.dart' show puppeteerFirefox, PuppeteerFirefox;
+export 'src/puppeteer_firefox.dart'
+    show puppeteerFirefox, PuppeteerFirefox, isPuppeteerFirefox;
 export 'src/target.dart' show Target;

--- a/lib/puppeteer.dart
+++ b/lib/puppeteer.dart
@@ -32,4 +32,5 @@ export 'src/page/page.dart'
         MediaFeature;
 export 'src/page/tracing.dart' show Tracing;
 export 'src/puppeteer.dart' show puppeteer, Puppeteer;
+export 'src/puppeteer_firefox.dart' show puppeteerFirefox, PuppeteerFirefox;
 export 'src/target.dart' show Target;

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import '../protocol/target.dart';
+import '../puppeteer.dart';
 
 abstract class Client {
   Future<Map<String, dynamic>> send(String method,
@@ -122,7 +123,12 @@ class Connection implements Client {
       if (session != null) {
         _logger.fine('◀ RECV $message');
 
-        session._onMessage(object);
+        if (isPuppeteerFirefox && session.isClosed) {
+          // Firefox often send message callback after Page#onClosed.
+          // onMessage should be ignored when session is already disconnected.
+        } else {
+          session._onMessage(object);
+        }
       }
     } else if (id != null) {
       _logger.fine('◀ RECV $id $message');

--- a/lib/src/downloader.dart
+++ b/lib/src/downloader.dart
@@ -111,6 +111,23 @@ String _downloadUrl(int revision) {
   }
 }
 
+const _baseUrlFirefox =
+    'https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central';
+
+// ignore: unused_element
+String _downloadUrlForFirefox(String version) {
+  if (Platform.isWindows) {
+    return '$_baseUrlFirefox/firefox-$version.en-US.win64.zip';
+  } else if (Platform.isLinux) {
+    return '$_baseUrlFirefox/firefox-$version.en-US.linux-x86_64.tar.bz2';
+  } else if (Platform.isMacOS) {
+    return '$_baseUrlFirefox/firefox-$version.en-US.mac.dmg';
+  } else {
+    throw UnsupportedError(
+        "Can't download chrome for platform ${Platform.operatingSystem}");
+  }
+}
+
 String getExecutablePath(String revisionPath) {
   if (Platform.isWindows) {
     return p.join(revisionPath, 'chrome-win', 'chrome.exe');

--- a/lib/src/downloader.dart
+++ b/lib/src/downloader.dart
@@ -17,7 +17,7 @@ class RevisionInfo {
 }
 
 const int _lastChromeRevision = 818858;
-const String _lastFirefoxRevision = '84.0a1';
+const String _lastFirefoxRevision = '85.0a1';
 
 Future<RevisionInfo> downloadChrome({int revision, String cachePath}) async {
   revision ??= _lastChromeRevision;

--- a/lib/src/page/page.dart
+++ b/lib/src/page/page.dart
@@ -917,7 +917,7 @@ function addPageBinding(bindingName) {
 function deliverResult(name, seq, result) {
   window[name]['callbacks'].get(seq).resolve(result);
   window[name]['callbacks'].delete(seq);
-}  
+}
 ''';
 
   static final _deliverError = '''
@@ -2084,7 +2084,8 @@ class ClientError implements Exception {
 
   static String _message(ExceptionDetails details) {
     if (details.exception != null) {
-      return details.exception.description ?? details.exception.value as String;
+      return details.exception.description ??
+          details.exception.value.toString();
     } else {
       var message = details.text;
       if (details.stackTrace != null) {

--- a/lib/src/puppeteer.dart
+++ b/lib/src/puppeteer.dart
@@ -13,6 +13,9 @@ import 'downloader.dart';
 import 'page/emulation_manager.dart';
 import 'plugin.dart';
 
+final bool isPuppeteerFirefox =
+    Platform.environment['PUPPETEER_PRODUCT'] == 'firefox';
+
 final Logger _logger = Logger('puppeteer.launcher');
 
 final List<String> _defaultArgs = <String>[
@@ -106,6 +109,22 @@ class Puppeteer {
       Map<String, String> environment,
       List<Plugin> plugins,
       Duration timeout}) async {
+    if (isPuppeteerFirefox) {
+      return puppeteerFirefox.launch(
+        executablePath: executablePath,
+        headless: headless,
+        devTools: devTools,
+        userDataDir: userDataDir,
+        defaultViewport: defaultViewport,
+        ignoreHttpsErrors: ignoreHttpsErrors,
+        slowMo: slowMo,
+        args: args,
+        ignoreDefaultArgs: ignoreDefaultArgs,
+        environment: environment,
+        timeout: timeout,
+      );
+    }
+
     devTools ??= false;
     headless ??= !devTools;
     timeout ??= Duration(seconds: 30);
@@ -260,6 +279,15 @@ class Puppeteer {
       List<String> args,
       String userDataDir,
       bool noSandboxFlag}) {
+    if (isPuppeteerFirefox) {
+      return puppeteerFirefox.defaultArgs(
+        devTools: devTools,
+        headless: headless,
+        args: args,
+        userDataDir: userDataDir,
+      );
+    }
+
     devTools ??= false;
     headless ??= !devTools;
     // In docker environment we want to force the '--no-sandbox' flag automatically

--- a/lib/src/puppeteer_firefox.dart
+++ b/lib/src/puppeteer_firefox.dart
@@ -1,0 +1,521 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:http/http.dart';
+import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
+import 'package:path/path.dart' as p;
+import '../puppeteer.dart';
+import 'browser.dart';
+import 'connection.dart';
+import 'devices.dart';
+import 'devices.dart' as devices_lib;
+import 'downloader.dart';
+import 'page/emulation_manager.dart';
+
+final Logger _logger = Logger('puppeteer.launcher_firefox');
+
+final puppeteerFirefox = PuppeteerFirefox._();
+
+/// Launch or connect to a firefox instance
+class PuppeteerFirefox {
+  PuppeteerFirefox._();
+
+  /// This method starts a Firefox instance and connects to the DevTools endpoint.
+  ///
+  /// If [executablePath] is not provided and no environment variable
+  /// `PUPPETEER_EXECUTABLE_PATH` is present, it will download the Chromium binaries
+  /// in a local folder (.local-chromium by default).
+  ///
+  /// ```
+  /// main() async {
+  ///   var browser = await puppeteer.launch();
+  ///   await browser.close();
+  /// }
+  /// ```
+  ///
+  /// Parameters:
+  ///  - `ignoreHttpsErrors`: Whether to ignore HTTPS errors during navigation.
+  ///     Defaults to `false`.
+  ///  - `headless`: Whether to run browser in [headless mode](https://developers.google.com/web/updates/2017/04/headless-chrome).
+  ///     Defaults to `true` unless the `devtools` option is `true`.
+  ///  - `executablePath`: Path to a Firefox executable to run instead of the bundled Firefox.
+  ///  - `slowMo` Slows down Puppeteer operations by the specified duration.
+  ///     Useful so that you can see what is going on.
+  ///  - `defaultViewport`: Sets a consistent viewport for each page.
+  ///     Defaults to an 1280x1024 viewport. `null` disables the default viewport.
+  ///  - `args` Additional arguments to pass to the browser instance. The list
+  ///    of Chromium flags can be found [here](http://peter.sh/experiments/chromium-command-line-switches/).
+  ///  - `environment` Specify environment variables that will be visible to the browser.
+  ///     Defaults to `Platform.environment`.
+  ///  - `devtools` Whether to auto-open a DevTools panel for each tab. If this
+  ///     option is `true`, the `headless` option will be set `false`.
+  ///  - `ignoreDefaultArgs` <[boolean]|[List]<[string]>> If `true`, then do not
+  ///     use [`puppeteer.defaultArgs()`]. If a list is given, then filter out
+  ///     the given default arguments. Dangerous option; use with care. Defaults to `false`.
+  ///  - `userDataDir` <[string]> Path to a [User Data Directory](https://chromium.googlesource.com/chromium/src/+/master/docs/user_data_dir.md).
+  ///  - `timeout` Maximum time to wait for the browser instance to start. Defaults to 30 seconds.
+  Future<Browser> launch(
+      {@required String executablePath,
+      bool headless,
+      bool devTools,
+      String userDataDir,
+      DeviceViewport defaultViewport = LaunchOptions.viewportNotSpecified,
+      bool ignoreHttpsErrors,
+      Duration slowMo,
+      List<String> args,
+      /* bool | List */ dynamic ignoreDefaultArgs,
+      Map<String, String> environment,
+      Duration timeout}) async {
+    devTools ??= false;
+    headless ??= !devTools;
+    timeout ??= Duration(seconds: 30);
+
+    var firefoxArgs = <String>[];
+    final defaultArguments = defaultArgs(
+      args: args,
+      userDataDir: userDataDir,
+      devTools: devTools,
+      headless: headless,
+    );
+    if (ignoreDefaultArgs == null || ignoreDefaultArgs == false) {
+      firefoxArgs.addAll(defaultArguments);
+    } else if (ignoreDefaultArgs is List) {
+      firefoxArgs.addAll(
+          defaultArguments.where((arg) => !ignoreDefaultArgs.contains(arg)));
+    } else if (args != null) {
+      firefoxArgs.addAll(args);
+    }
+
+    if (!firefoxArgs.any((a) => a.startsWith('--remote-debugging-'))) {
+      firefoxArgs.add('--remote-debugging-port=0');
+    }
+
+    Directory temporaryUserDataDir;
+    if (!firefoxArgs.contains('-profile') &&
+        !firefoxArgs.contains('--profile')) {
+      temporaryUserDataDir = await _createProfile();
+      firefoxArgs.add('--profile');
+      firefoxArgs.add(temporaryUserDataDir.path);
+    }
+
+    executablePath ??= await _inferExecutablePath();
+
+    var launchOptions =
+        LaunchOptions(args: firefoxArgs, defaultViewport: defaultViewport);
+
+    _logger.info('Start $executablePath with $firefoxArgs');
+    final firefoxProcess = await Process.start(
+        executablePath, launchOptions.args,
+        environment: environment);
+
+    // ignore: unawaited_futures
+    var firefoxProcessExit = firefoxProcess.exitCode.then((exitCode) {
+      _logger.info('Firefox exit with $exitCode.');
+      if (temporaryUserDataDir != null) {
+        try {
+          _logger.info('Clean ${temporaryUserDataDir.path}');
+          temporaryUserDataDir.deleteSync(recursive: true);
+        } catch (error) {
+          _logger.info('Delete temporary file failed', error);
+        }
+      }
+    });
+
+    var webSocketUrl = await _waitForWebSocketUrl(firefoxProcess)
+        .timeout(timeout, onTimeout: () => null);
+    if (webSocketUrl != null) {
+      var connection = await Connection.create(webSocketUrl, delay: slowMo);
+
+      var browser = createBrowser(
+        firefoxProcess,
+        connection,
+        defaultViewport: launchOptions.computedDefaultViewport,
+        closeCallback: () async {
+          if (temporaryUserDataDir != null) {
+            await _killFirefox(firefoxProcess);
+          } else {
+            // If there is a custom data-directory we need to give firefox a chance
+            // to save the last data
+            // Attempt to close firefox gracefully
+            await connection.send('Browser.close').catchError((error) async {
+              await _killFirefox(firefoxProcess);
+            });
+          }
+
+          return firefoxProcessExit;
+        },
+        ignoreHttpsErrors: ignoreHttpsErrors,
+        plugins: [],
+      );
+      final targetFuture =
+          browser.waitForTarget((target) => target.type == 'page');
+      await browser.targetApi.setDiscoverTargets(true);
+      await targetFuture;
+      return browser;
+    } else {
+      throw Exception('Not able to connect to Chrome DevTools');
+    }
+  }
+
+  /// This method attaches Puppeteer to an existing Chromium instance.
+  ///
+  /// Parameters:
+  ///  - `browserWSEndpoint`: a browser websocket endpoint to connect to.
+  ///  - `browserURL`:  a browser url to connect to, in format `http://${host}:${port}`.
+  ///     Use interchangeably with `browserWSEndpoint` to let Puppeteer fetch it
+  ///     from [metadata endpoint](https://chromedevtools.github.io/devtools-protocol/#how-do-i-access-the-browser-target).
+  ///  - `ignoreHTTPSErrors`: Whether to ignore HTTPS errors during navigation. Defaults to `false`.
+  ///  - `defaultViewport`: Sets a consistent viewport for each page. Defaults to
+  ///     an 1280x1024 viewport.  `null` disables the default viewport.
+  ///  - `slowMo`: Slows down Puppeteer operations by the specified amount of milliseconds.
+  ///     Useful so that you can see what is going on.
+  Future<Browser> connect({
+    String browserWsEndpoint,
+    String browserUrl,
+    DeviceViewport defaultViewport = LaunchOptions.viewportNotSpecified,
+    bool ignoreHttpsErrors,
+    Duration slowMo,
+  }) async {
+    assert(
+        (browserWsEndpoint != null || browserUrl != null) &&
+            browserWsEndpoint != browserUrl,
+        'Exactly one of browserWSEndpoint, browserURL or transport must be passed to puppeteer.connect');
+
+    var connectOptions =
+        LaunchOptions(args: null, defaultViewport: defaultViewport);
+
+    Connection connection;
+    if (browserWsEndpoint != null) {
+      connection = await Connection.create(browserWsEndpoint, delay: slowMo);
+    } else if (browserUrl != null) {
+      var connectionURL = await _wsEndpoint(browserUrl);
+      connection = await Connection.create(connectionURL, delay: slowMo);
+    }
+
+    var browserContextIds = await connection.targetApi.getBrowserContexts();
+    var browser = createBrowser(null, connection,
+        browserContextIds: browserContextIds,
+        ignoreHttpsErrors: ignoreHttpsErrors,
+        defaultViewport: connectOptions.computedDefaultViewport,
+        plugins: [],
+        closeCallback: () =>
+            connection.send('Browser.close').catchError((e) => null));
+    await browser.targetApi.setDiscoverTargets(true);
+    return browser;
+  }
+
+  Devices get devices => devices_lib.devices;
+
+  List<String> defaultArgs({
+    bool devTools,
+    bool headless,
+    List<String> args,
+    String userDataDir,
+  }) {
+    devTools ??= false;
+    headless ??= !devTools;
+
+    return [
+      '--no-remote',
+      '--foreground',
+      if (Platform.isWindows) '--wait-for-browser',
+      if (userDataDir != null) '--profile',
+      if (userDataDir != null) userDataDir,
+      if (headless) '--headless',
+      if (devTools) '--devtools',
+      if (args == null || args.every((a) => a.startsWith('-'))) 'about:blank',
+      ...?args
+    ];
+  }
+
+  Future<Directory> _createProfile() async {
+    final profileDir =
+        await Directory.systemTemp.createTemp('puppeteer_dev_firefox_profile-');
+    const server = 'dummy.test';
+    const defaultPreferences = <String, dynamic>{
+      // Make sure Shield doesn't hit the network.
+      'app.normandy.api_url': '',
+      // Disable Firefox old build background check
+      'app.update.checkInstallTime': false,
+      // Disable automatically upgrading Firefox
+      'app.update.disabledForTesting': true,
+
+      // Increase the APZ content response timeout to 1 minute
+      'apz.content_response_timeout': 60000,
+
+      // Prevent various error message on the console
+      // jest-puppeteer asserts that no error message is emitted by the console
+      'browser.contentblocking.features.standard':
+          '-tp,tpPrivate,cookieBehavior0,-cm,-fp',
+
+      // Enable the dump function: which sends messages to the system
+      // console
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=1543115
+      'browser.dom.window.dump.enabled': true,
+      // Disable topstories
+      'browser.newtabpage.activity-stream.feeds.system.topstories': false,
+      // Always display a blank page
+      'browser.newtabpage.enabled': false,
+      // Background thumbnails in particular cause grief: and disabling
+      // thumbnails in general cannot hurt
+      'browser.pagethumbnails.capturing_disabled': true,
+
+      // Disable safebrowsing components.
+      'browser.safebrowsing.blockedURIs.enabled': false,
+      'browser.safebrowsing.downloads.enabled': false,
+      'browser.safebrowsing.malware.enabled': false,
+      'browser.safebrowsing.passwords.enabled': false,
+      'browser.safebrowsing.phishing.enabled': false,
+
+      // Disable updates to search engines.
+      'browser.search.update': false,
+      // Do not restore the last open set of tabs if the browser has crashed
+      'browser.sessionstore.resume_from_crash': false,
+      // Skip check for default browser on startup
+      'browser.shell.checkDefaultBrowser': false,
+
+      // Disable newtabpage
+      'browser.startup.homepage': 'about:blank',
+      // Do not redirect user when a milstone upgrade of Firefox is detected
+      'browser.startup.homepage_override.mstone': 'ignore',
+      // Start with a blank page about:blank
+      'browser.startup.page': 0,
+
+      // Do not allow background tabs to be zombified on Android: otherwise for
+      // tests that open additional tabs: the test harness tab itself might get
+      // unloaded
+      'browser.tabs.disableBackgroundZombification': false,
+      // Do not warn when closing all other open tabs
+      'browser.tabs.warnOnCloseOtherTabs': false,
+      // Do not warn when multiple tabs will be opened
+      'browser.tabs.warnOnOpen': false,
+
+      // Disable the UI tour.
+      'browser.uitour.enabled': false,
+      // Turn off search suggestions in the location bar so as not to trigger
+      // network connections.
+      'browser.urlbar.suggest.searches': false,
+      // Disable first run splash page on Windows 10
+      'browser.usedOnWindows10.introURL': '',
+      // Do not warn on quitting Firefox
+      'browser.warnOnQuit': false,
+
+      // Defensively disable data reporting systems
+      'datareporting.healthreport.documentServerURI':
+          'http://$server/dummy/healthreport/',
+      'datareporting.healthreport.logging.consoleEnabled': false,
+      'datareporting.healthreport.service.enabled': false,
+      'datareporting.healthreport.service.firstRun': false,
+      'datareporting.healthreport.uploadEnabled': false,
+
+      // Do not show datareporting policy notifications which can interfere with tests
+      'datareporting.policy.dataSubmissionEnabled': false,
+      'datareporting.policy.dataSubmissionPolicyBypassNotification': true,
+
+      // DevTools JSONViewer sometimes fails to load dependencies with its require.js.
+      // This doesn't affect Puppeteer but spams console (Bug 1424372)
+      'devtools.jsonview.enabled': false,
+
+      // Disable popup-blocker
+      'dom.disable_open_during_load': false,
+
+      // Enable the support for File object creation in the content process
+      // Required for |Page.setFileInputFiles| protocol method.
+      'dom.file.createInChild': true,
+
+      // Disable the ProcessHangMonitor
+      'dom.ipc.reportProcessHangs': false,
+
+      // Disable slow script dialogues
+      'dom.max_chrome_script_run_time': 0,
+      'dom.max_script_run_time': 0,
+
+      // Only load extensions from the application and user profile
+      // AddonManager.SCOPE_PROFILE + AddonManager.SCOPE_APPLICATION
+      'extensions.autoDisableScopes': 0,
+      'extensions.enabledScopes': 5,
+
+      // Disable metadata caching for installed add-ons by default
+      'extensions.getAddons.cache.enabled': false,
+
+      // Disable installing any distribution extensions or add-ons.
+      'extensions.installDistroAddons': false,
+
+      // Disabled screenshots extension
+      'extensions.screenshots.disabled': true,
+
+      // Turn off extension updates so they do not bother tests
+      'extensions.update.enabled': false,
+
+      // Turn off extension updates so they do not bother tests
+      'extensions.update.notifyUser': false,
+
+      // Make sure opening about:addons will not hit the network
+      'extensions.webservice.discoverURL': 'http://$server/dummy/discoveryURL',
+
+      // Allow the application to have focus even it runs in the background
+      'focusmanager.testmode': true,
+      // Disable useragent updates
+      'general.useragent.updates.enabled': false,
+      // Always use network provider for geolocation tests so we bypass the
+      // macOS dialog raised by the corelocation provider
+      'geo.provider.testing': true,
+      // Do not scan Wifi
+      'geo.wifi.scan': false,
+      // No hang monitor
+      'hangmonitor.timeout': 0,
+      // Show chrome errors and warnings in the error console
+      'javascript.options.showInConsole': true,
+
+      // Disable download and usage of OpenH264: and Widevine plugins
+      'media.gmp-manager.updateEnabled': false,
+      // Prevent various error message on the console
+      // jest-puppeteer asserts that no error message is emitted by the console
+      'network.cookie.cookieBehavior': 0,
+
+      // Do not prompt for temporary redirects
+      'network.http.prompt-temp-redirect': false,
+
+      // Disable speculative connections so they are not reported as leaking
+      // when they are hanging around
+      'network.http.speculative-parallel-limit': 0,
+
+      // Do not automatically switch between offline and online
+      'network.manage-offline-status': false,
+
+      // Make sure SNTP requests do not hit the network
+      'network.sntp.pools': server,
+
+      // Disable Flash.
+      'plugin.state.flash': 0,
+
+      'privacy.trackingprotection.enabled': false,
+
+      // Enable Remote Agent
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=1544393
+      'remote.enabled': true,
+
+      // Don't do network connections for mitm priming
+      'security.certerrors.mitm.priming.enabled': false,
+      // Local documents have access to all other local documents,
+      // including directory listings
+      'security.fileuri.strict_origin_policy': false,
+      // Do not wait for the notification button security delay
+      'security.notification_enable_delay': 0,
+
+      // Ensure blocklist updates do not hit the network
+      'services.settings.server': 'http://$server/dummy/blocklist/',
+
+      // Do not automatically fill sign-in forms with known usernames and
+      // passwords
+      'signon.autofillForms': false,
+      // Disable password capture, so that tests that include forms are not
+      // influenced by the presence of the persistent doorhanger notification
+      'signon.rememberSignons': false,
+
+      // Disable first-run welcome page
+      'startup.homepage_welcome_url': 'about:blank',
+
+      // Disable first-run welcome page
+      'startup.homepage_welcome_url.additional': '',
+
+      // Disable browser animations (tabs, fullscreen, sliding alerts)
+      'toolkit.cosmeticAnimations.enabled': false,
+
+      // Prevent starting into safe mode after application crashes
+      'toolkit.startup.max_resumed_crashes': -1,
+    };
+
+    final userJS = <String>[];
+    defaultPreferences.forEach((key, value) {
+      userJS.add('user_pref(${jsonEncode(key)}, ${jsonEncode(value)});');
+    });
+    await File('${profileDir.path}/user.js').writeAsString(userJS.join('\n'));
+    await File('${profileDir.path}/prefs.js').writeAsString('');
+
+    return profileDir;
+  }
+}
+
+Future<String> _wsEndpoint(String browserURL) async {
+  var response = await read(p.url.join(browserURL, 'json/version'));
+  var decodedResponse = jsonDecode(response) as Map<String, dynamic>;
+
+  return decodedResponse['webSocketDebuggerUrl'] as String;
+}
+
+Future _killFirefox(Process process) {
+  if (Platform.isWindows) {
+    // Allow a clean exit on Windows.
+    // With `process.kill`, it seems that firefox retain a lock on the user-data directory
+    Process.runSync('taskkill', ['/pid', process.pid.toString(), '/T', '/F']);
+  } else {
+    process.kill(ProcessSignal.sigkill);
+  }
+
+  return process.exitCode;
+}
+
+final _devToolRegExp = RegExp(r'^DevTools listening on (ws:\/\/.*)$');
+
+Future<String> _waitForWebSocketUrl(Process firefoxProcess) async {
+  await for (String line in firefoxProcess.stderr
+      .transform(Utf8Decoder())
+      .transform(LineSplitter())) {
+    _logger.warning('[Firefox stderr]: $line');
+    var match = _devToolRegExp.firstMatch(line);
+    if (match != null) {
+      return match.group(1);
+    }
+  }
+  throw Exception('Websocket url not found');
+}
+
+Future<String> _inferExecutablePath() async {
+  var executablePath = Platform.environment['PUPPETEER_EXECUTABLE_PATH'];
+  if (executablePath != null) {
+    var file = File(executablePath);
+    if (!file.existsSync()) {
+      executablePath = getExecutablePath(executablePath);
+      if (!File(executablePath).existsSync()) {
+        throw Exception(
+            'The environment variable contains PUPPETEER_EXECUTABLE_PATH with '
+            'value (${Platform.environment['PUPPETEER_EXECUTABLE_PATH']}) but we cannot '
+            'find the Firefox executable');
+      }
+    }
+    return executablePath;
+  } else {
+    // Downloading Firefox is much more complecated than downloading Chrome.
+    // We have to extract not only zip, but also tar.bz2 (for Linux) and dmg (for macOS).
+    // https://github.com/puppeteer/puppeteer/blob/main/src/node/BrowserFetcher.ts
+    //
+    // Pull Request is welcome :)
+    throw UnimplementedError(
+        'Downloading firefox nightly is not implemeted yet. Please specify executablePath.');
+  }
+}
+
+class LaunchOptions {
+  static const DeviceViewport viewportNotSpecified = DeviceViewport(width: -1);
+  static const DeviceViewport viewportNotOverride = DeviceViewport(width: -2);
+  final List<String> args;
+  final DeviceViewport defaultViewport;
+
+  LaunchOptions({@required this.args, @required this.defaultViewport});
+
+  LaunchOptions replace(
+      {List<String> args,
+      DeviceViewport defaultViewport = viewportNotOverride}) {
+    return LaunchOptions(
+        args: args ?? this.args,
+        defaultViewport: identical(defaultViewport, viewportNotOverride)
+            ? this.defaultViewport
+            : defaultViewport);
+  }
+
+  DeviceViewport get computedDefaultViewport =>
+      identical(defaultViewport, LaunchOptions.viewportNotSpecified)
+          ? DeviceViewport()
+          : defaultViewport;
+}

--- a/lib/src/puppeteer_firefox.dart
+++ b/lib/src/puppeteer_firefox.dart
@@ -55,7 +55,7 @@ class PuppeteerFirefox {
   ///  - `userDataDir` <[string]> Path to a [User Data Directory](https://chromium.googlesource.com/chromium/src/+/master/docs/user_data_dir.md).
   ///  - `timeout` Maximum time to wait for the browser instance to start. Defaults to 30 seconds.
   Future<Browser> launch(
-      {@required String executablePath,
+      {String executablePath,
       bool headless,
       bool devTools,
       String userDataDir,
@@ -486,13 +486,8 @@ Future<String> _inferExecutablePath() async {
     }
     return executablePath;
   } else {
-    // Downloading Firefox is much more complecated than downloading Chrome.
-    // We have to extract not only zip, but also tar.bz2 (for Linux) and dmg (for macOS).
-    // https://github.com/puppeteer/puppeteer/blob/main/src/node/BrowserFetcher.ts
-    //
-    // Pull Request is welcome :)
-    throw UnimplementedError(
-        'Downloading firefox nightly is not implemeted yet. Please specify executablePath.');
+    // We download locally a version of firefox and use it.
+    return (await downloadFirefox()).executablePath;
   }
 }
 

--- a/lib/src/puppeteer_firefox.dart
+++ b/lib/src/puppeteer_firefox.dart
@@ -12,6 +12,9 @@ import 'devices.dart' as devices_lib;
 import 'downloader.dart';
 import 'page/emulation_manager.dart';
 
+final bool isPuppeteerFirefox =
+    Platform.environment['PUPPETEER_PRODUCT'] == 'firefox';
+
 final Logger _logger = Logger('puppeteer.launcher_firefox');
 
 final puppeteerFirefox = PuppeteerFirefox._();

--- a/test/accessibility_test.dart
+++ b/test/accessibility_test.dart
@@ -1,5 +1,6 @@
 import 'package:puppeteer/puppeteer.dart';
 import 'package:test/test.dart';
+import 'utils/test_api.dart';
 import 'utils/utils.dart';
 
 void main() {
@@ -29,9 +30,7 @@ void main() {
     page = null;
   });
 
-  group('Accessibility', () {
-    if (isPuppeteerFirefox) return;
-
+  groupFailsFirefox('Accessibility', () {
     test('should work', () async {
       await page.setContent('''
       <head>

--- a/test/accessibility_test.dart
+++ b/test/accessibility_test.dart
@@ -30,6 +30,8 @@ void main() {
   });
 
   group('Accessibility', () {
+    if (isPuppeteerFirefox) return;
+
     test('should work', () async {
       await page.setContent('''
       <head>

--- a/test/browser_context_test.dart
+++ b/test/browser_context_test.dart
@@ -54,6 +54,8 @@ void main() {
       expect(await browser.pages, hasLength(1));
     });
     test('window.open should use parent tab context', () async {
+      if (isPuppeteerFirefox) return;
+
       var context = await browser.createIncognitoBrowserContext();
       var page = await context.newPage();
       await page.goto(server.emptyPage);
@@ -67,6 +69,8 @@ void main() {
       await context.close();
     });
     test('should fire target events', () async {
+      if (isPuppeteerFirefox) return;
+
       var context = await browser.createIncognitoBrowserContext();
       var events = [];
       context.onTargetCreated
@@ -90,6 +94,8 @@ void main() {
       await context.close();
     });
     test('should wait for a target', () async {
+      if (isPuppeteerFirefox) return;
+
       var context = await browser.createIncognitoBrowserContext();
       var resolved = false;
       var targetPromise =

--- a/test/browser_context_test.dart
+++ b/test/browser_context_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:puppeteer/puppeteer.dart';
 import 'package:test/test.dart';
+import 'utils/test_api.dart';
 import 'utils/utils.dart';
 
 // ignore_for_file: prefer_interpolation_to_compose_strings
@@ -53,9 +54,7 @@ void main() {
       await context.close();
       expect(await browser.pages, hasLength(1));
     });
-    test('window.open should use parent tab context', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('window.open should use parent tab context', () async {
       var context = await browser.createIncognitoBrowserContext();
       var page = await context.newPage();
       await page.goto(server.emptyPage);
@@ -68,9 +67,7 @@ void main() {
       expect(popupTarget.browserContext, equals(context));
       await context.close();
     });
-    test('should fire target events', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should fire target events', () async {
       var context = await browser.createIncognitoBrowserContext();
       var events = [];
       context.onTargetCreated
@@ -93,9 +90,7 @@ void main() {
           ]));
       await context.close();
     });
-    test('should wait for a target', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should wait for a target', () async {
       var context = await browser.createIncognitoBrowserContext();
       var resolved = false;
       var targetPromise =

--- a/test/browser_test.dart
+++ b/test/browser_test.dart
@@ -31,7 +31,12 @@ void main() {
     test('should include WebKit', () async {
       var userAgent = await browser.userAgent;
       expect(userAgent.length, greaterThan(0));
-      expect(userAgent, contains('WebKit'));
+
+      if (isPuppeteerFirefox) {
+        expect(userAgent, contains('Gecko'));
+      } else {
+        expect(userAgent, contains('WebKit'));
+      }
     });
   });
 

--- a/test/click_test.dart
+++ b/test/click_test.dart
@@ -1,5 +1,6 @@
 import 'package:puppeteer/puppeteer.dart';
 import 'package:test/test.dart';
+import 'utils/test_api.dart';
 import 'utils/utils.dart';
 
 // ignore_for_file: prefer_interpolation_to_compose_strings
@@ -37,9 +38,8 @@ void main() {
       await page.click('button');
       expect(await page.evaluate('() => result'), equals('Clicked'));
     });
-    test('should click the button if window.Node is removed', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should click the button if window.Node is removed',
+        () async {
       await page.goto(server.prefix + '/input/button.html');
       await page.evaluate('() => delete window.Node');
       await page.click('button');
@@ -65,9 +65,7 @@ void main() {
       await page.click('button');
       expect(await page.evaluate('() => result'), equals('Clicked'));
     });
-    test('should click with disabled javascript', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should click with disabled javascript', () async {
       await page.setJavaScriptEnabled(false);
       await page.goto(server.prefix + '/wrappedlink.html');
       await Future.wait([page.click('a'), page.waitForNavigation()]);
@@ -156,9 +154,7 @@ void main() {
       expect(await page.evaluate('() => result.check'), isFalse);
     });
 
-    test('should click on checkbox label and toggle', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should click on checkbox label and toggle', () async {
       await page.goto(server.prefix + '/input/checkbox.html');
       expect(await page.evaluate('() => result.check'), isNull);
       await page.click('label[for="agree"]');

--- a/test/click_test.dart
+++ b/test/click_test.dart
@@ -38,6 +38,8 @@ void main() {
       expect(await page.evaluate('() => result'), equals('Clicked'));
     });
     test('should click the button if window.Node is removed', () async {
+      if (isPuppeteerFirefox) return;
+
       await page.goto(server.prefix + '/input/button.html');
       await page.evaluate('() => delete window.Node');
       await page.click('button');
@@ -64,6 +66,8 @@ void main() {
       expect(await page.evaluate('() => result'), equals('Clicked'));
     });
     test('should click with disabled javascript', () async {
+      if (isPuppeteerFirefox) return;
+
       await page.setJavaScriptEnabled(false);
       await page.goto(server.prefix + '/wrappedlink.html');
       await Future.wait([page.click('a'), page.waitForNavigation()]);
@@ -99,7 +103,7 @@ void main() {
     });
     test('should click offscreen buttons', () async {
       await page.goto(server.prefix + '/offscreenbuttons.html');
-      var messages = [];
+      var messages = <String>[];
       page.onConsole.listen((message) {
         messages.add(message.text);
       });
@@ -109,7 +113,7 @@ void main() {
         await page.click('#btn$i');
       }
       expect(
-          messages,
+          messages.where((log) => log.startsWith('button')),
           equals([
             'button #0 clicked',
             'button #1 clicked',
@@ -153,6 +157,8 @@ void main() {
     });
 
     test('should click on checkbox label and toggle', () async {
+      if (isPuppeteerFirefox) return;
+
       await page.goto(server.prefix + '/input/checkbox.html');
       expect(await page.evaluate('() => result.check'), isNull);
       await page.click('label[for="agree"]');

--- a/test/coverage_test.dart
+++ b/test/coverage_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'package:puppeteer/puppeteer.dart';
 import 'package:test/test.dart';
+import 'utils/test_api.dart';
 import 'utils/utils.dart';
 
 // ignore_for_file: prefer_interpolation_to_compose_strings
@@ -33,9 +34,7 @@ void main() {
     page = null;
   });
 
-  group('JSCoverage', () {
-    if (isPuppeteerFirefox) return;
-
+  groupChromeOnly('JSCoverage', () {
     test('should work', () async {
       await page.coverage.startJSCoverage();
       await page.goto(server.prefix + '/jscoverage/simple.html',
@@ -144,9 +143,7 @@ void main() {
     });
   });
 
-  group('CSSCoverage', () {
-    if (isPuppeteerFirefox) return;
-
+  groupChromeOnly('CSSCoverage', () {
     test('should work', () async {
       await page.coverage.startCSSCoverage();
       await page.goto(server.prefix + '/csscoverage/simple.html');

--- a/test/coverage_test.dart
+++ b/test/coverage_test.dart
@@ -34,6 +34,8 @@ void main() {
   });
 
   group('JSCoverage', () {
+    if (isPuppeteerFirefox) return;
+
     test('should work', () async {
       await page.coverage.startJSCoverage();
       await page.goto(server.prefix + '/jscoverage/simple.html',
@@ -143,6 +145,8 @@ void main() {
   });
 
   group('CSSCoverage', () {
+    if (isPuppeteerFirefox) return;
+
     test('should work', () async {
       await page.coverage.startCSSCoverage();
       await page.goto(server.prefix + '/csscoverage/simple.html');

--- a/test/dialog_test.dart
+++ b/test/dialog_test.dart
@@ -33,7 +33,9 @@ void main() {
     test('should fire', () async {
       page.onDialog.listen((dialog) {
         expect(dialog.type, equals(DialogType.alert));
-        expect(dialog.defaultValue, equals(''));
+        if (!isPuppeteerFirefox) {
+          expect(dialog.defaultValue, equals(''));
+        }
         expect(dialog.message, equals('yo'));
         dialog.accept();
       });
@@ -42,7 +44,9 @@ void main() {
     test('should allow accepting prompts', () async {
       page.onDialog.listen((dialog) {
         expect(dialog.type, equals(DialogType.prompt));
-        expect(dialog.defaultValue, equals('yes.'));
+        if (!isPuppeteerFirefox) {
+          expect(dialog.defaultValue, equals('yes.'));
+        }
         expect(dialog.message, equals('question?'));
         dialog.accept(promptText: 'answer!');
       });

--- a/test/doc_examples_test.dart
+++ b/test/doc_examples_test.dart
@@ -69,6 +69,8 @@ void main() {
       await main();
     });
     test('waitForTarget', () async {
+      if (isPuppeteerFirefox) return;
+
       //---
       var newWindowTarget = browser.waitForTarget((target) =>
           target.url ==
@@ -81,6 +83,8 @@ void main() {
     });
   });
   group('BrowserContext', () {
+    if (isPuppeteerFirefox) return;
+
     test('overridePermissions', () async {
       var context = browser.defaultBrowserContext;
       await context.overridePermissions(
@@ -151,6 +155,8 @@ void main() {
       await page.evaluate("() => console.log('hello', 5, {foo: 'bar'})");
     });
     group('onPopup', () {
+      if (isPuppeteerFirefox) return;
+
       test(0, () async {
         //----
         var popupFuture = page.onPopup.first;
@@ -227,6 +233,9 @@ void main() {
       await browser.close();
     });
     test('emulateMediaType', () async {
+      if (isPuppeteerFirefox) return;
+
+      //----
       expect(await page.evaluate("() => matchMedia('screen').matches"), isTrue);
       expect(await page.evaluate("() => matchMedia('print').matches"), isFalse);
 
@@ -238,6 +247,7 @@ void main() {
       await page.emulateMediaType(null);
       expect(await page.evaluate("() => matchMedia('screen').matches"), isTrue);
       expect(await page.evaluate("() => matchMedia('print').matches"), isFalse);
+      //----
     });
     group('evaluate', () {
       test(0, () async {
@@ -280,6 +290,8 @@ void main() {
       await page.evaluateOnNewDocument(preloadFile);
     });
     group('exposeFunction', () {
+      if (isPuppeteerFirefox) return;
+
       test(0, () async {
         //----
         //+import 'dart:convert';
@@ -333,12 +345,18 @@ void main() {
       });
     });
     test('pdf', () async {
+      if (isPuppeteerFirefox) return;
+
+      //----
       // Generates a PDF with 'screen' media type.
       await page.emulateMediaType(MediaType.screen);
       await page.pdf(
           output: File(exampleValue('_page.pdf', 'page.pdf')).openWrite());
+      //----
     });
     test('queryObjects', () async {
+      if (isPuppeteerFirefox) return;
+
       // There is a bug currently with queryObjects if the page has navigated
       // before.
       // https://github.com/GoogleChrome/puppeteer/issues/4263
@@ -370,9 +388,16 @@ void main() {
           'select#colors', ['red', 'green', 'blue']); // multiple selections
     });
     test('setGeolocation', () async {
+      if (isPuppeteerFirefox) return;
+
+      //----
       await page.setGeolocation(latitude: 59.95, longitude: 30.31667);
+      //----
     });
     test('setRequestInterception', () async {
+      if (isPuppeteerFirefox) return;
+
+      //----
       var browser = await puppeteer.launch();
       var page = await browser.newPage();
       await page.setRequestInterception(true);
@@ -386,6 +411,7 @@ void main() {
       });
       await page.goto(exampleValue(server.hostUrl, 'https://example.com'));
       await browser.close();
+      //----
     });
     test('type', () async {
       // Types instantly
@@ -486,6 +512,8 @@ void main() {
       await main();
     });
     test('waitForFileChooser', () async {
+      if (isPuppeteerFirefox) return;
+
       await page.goto(server.assetUrl('doc_examples_3.html'));
       //------
       var futureFileChooser = page.waitForFileChooser();
@@ -540,6 +568,8 @@ void main() {
       expect(divsCounts, greaterThan(0));
     });
     test('click', () async {
+      if (isPuppeteerFirefox) return;
+
       var frame = page.mainFrame;
       //---
       var responseFuture = page.waitForNavigation();
@@ -692,6 +722,8 @@ void main() {
       });
     });
     test('sendCharacter', () async {
+      if (isPuppeteerFirefox) return;
+
       var input = await page.$('input');
       await input.focus();
       //----
@@ -724,6 +756,9 @@ void main() {
       await page.mouse.up();
     });
     test('wheel', () async {
+      if (isPuppeteerFirefox) return;
+
+      //----
       await page.goto(exampleValue('${server.assetUrl('input/wheel.html')}',
           r'https://mdn.mozillademos.org/en-US/docs/Web/API/Element/wheel_event$samples/Scaling_an_element_via_the_wheel?revision=1587366'));
       var elem = await page.$('div');
@@ -731,6 +766,7 @@ void main() {
       await page.mouse.move(Point(boundingBox.left + boundingBox.width / 2,
           boundingBox.top + boundingBox.height / 2));
       await page.mouse.wheel(deltaY: -100);
+      //----
     });
   });
   group('ExecutionContext', () {
@@ -894,6 +930,8 @@ void main() {
     });
   });
   group('Request', () {
+    if (isPuppeteerFirefox) return;
+
     test('continueRequest', () async {
       //---
       await page.setRequestInterception(true);
@@ -947,6 +985,8 @@ void main() {
     });
   });
   group('Worker', () {
+    if (isPuppeteerFirefox) return;
+
     test('class', () async {
       page.onWorkerCreated
           .listen((worker) => print('Worker created: ${worker.url}'));
@@ -959,6 +999,8 @@ void main() {
     });
   });
   group('Coverage', () {
+    if (isPuppeteerFirefox) return;
+
     test('class', () async {
       //---
       // Enable both JavaScript and CSS coverage
@@ -986,6 +1028,8 @@ void main() {
     });
   });
   group('Tracing', () {
+    if (isPuppeteerFirefox) return;
+
     test('class', () async {
       //----
       await page.tracing.start();
@@ -998,6 +1042,8 @@ void main() {
     });
   });
   group('Accessibility', () {
+    if (isPuppeteerFirefox) return;
+
     group('snapshot', () {
       test(0, () async {
         var snapshot = await page.accessibility.snapshot();
@@ -1020,6 +1066,8 @@ void main() {
     });
   });
   group('FileChooser', () {
+    if (isPuppeteerFirefox) return;
+
     test('class', () async {
       await page.goto(server.assetUrl('doc_examples_3.html'));
       //------

--- a/test/element_handle_test.dart
+++ b/test/element_handle_test.dart
@@ -54,6 +54,8 @@ void main() {
   });
 
   group('ElementHandle.boundingBox', () {
+    if (isPuppeteerFirefox) return;
+
     test('should work', () async {
       await page.setViewport(DeviceViewport(width: 500, height: 500));
       await page.goto(server.assetUrl('grid.html'));
@@ -106,6 +108,8 @@ void main() {
   });
 
   group('ElementHandle.boxModel', () {
+    if (isPuppeteerFirefox) return;
+
     test('should work', () async {
       await page.goto(server.prefix + '/resetcss.html');
 
@@ -244,6 +248,8 @@ void main() {
   });
 
   group('ElementHandle.hover', () {
+    if (isPuppeteerFirefox) return;
+
     test('should work', () async {
       await page.goto(server.prefix + '/input/scrollable.html');
       var button = await page.$('#button-6');

--- a/test/element_handle_test.dart
+++ b/test/element_handle_test.dart
@@ -1,5 +1,6 @@
 import 'package:puppeteer/puppeteer.dart';
 import 'package:test/test.dart';
+import 'utils/test_api.dart';
 import 'utils/utils.dart';
 
 // ignore_for_file: prefer_interpolation_to_compose_strings
@@ -53,9 +54,7 @@ void main() {
     });
   });
 
-  group('ElementHandle.boundingBox', () {
-    if (isPuppeteerFirefox) return;
-
+  groupFailsFirefox('ElementHandle.boundingBox', () {
     test('should work', () async {
       await page.setViewport(DeviceViewport(width: 500, height: 500));
       await page.goto(server.assetUrl('grid.html'));
@@ -107,9 +106,7 @@ void main() {
     });
   });
 
-  group('ElementHandle.boxModel', () {
-    if (isPuppeteerFirefox) return;
-
+  groupFailsFirefox('ElementHandle.boxModel', () {
     test('should work', () async {
       await page.goto(server.prefix + '/resetcss.html');
 
@@ -248,9 +245,7 @@ void main() {
   });
 
   group('ElementHandle.hover', () {
-    if (isPuppeteerFirefox) return;
-
-    test('should work', () async {
+    testFailsFirefox('should work', () async {
       await page.goto(server.prefix + '/input/scrollable.html');
       var button = await page.$('#button-6');
       await button.hover();

--- a/test/emulation_test.dart
+++ b/test/emulation_test.dart
@@ -82,6 +82,8 @@ void main() {
       expect(await page.evaluate('() => Modernizr.touchevents'), isTrue);
     });
     test('should support landscape emulation', () async {
+      if (isPuppeteerFirefox) return;
+
       await page.goto(server.prefix + '/mobile.html');
       await page.setViewport(puppeteer.devices.iPhone6Landscape.viewport);
       expect(await page.evaluate('() => screen.orientation.type'),
@@ -113,6 +115,8 @@ void main() {
 
   group('Page.emulateMediaType', () {
     test('should work', () async {
+      if (isPuppeteerFirefox) return;
+
       expect(await page.evaluate("() => window.matchMedia('screen').matches"),
           isTrue);
       expect(await page.evaluate("() => window.matchMedia('print').matches"),
@@ -135,6 +139,8 @@ void main() {
   });
 
   group('Page.emulateMediaFeatures', () {
+    if (isPuppeteerFirefox) return;
+
     test('should work ddd', () async {
       await page
           .emulateMediaFeatures([MediaFeature.prefersReducedMotion('reduce')]);
@@ -238,6 +244,8 @@ void main() {
   });
 
   group('Page.emulateTimezone', () {
+    if (isPuppeteerFirefox) return;
+
     test('should work', () async {
       await page.evaluate('''() => {
       globalThis.date = new Date(1479579154987);

--- a/test/emulation_test.dart
+++ b/test/emulation_test.dart
@@ -1,5 +1,6 @@
 import 'package:puppeteer/puppeteer.dart';
 import 'package:test/test.dart';
+import 'utils/test_api.dart';
 import 'utils/utils.dart';
 
 // ignore_for_file: prefer_interpolation_to_compose_strings
@@ -81,9 +82,7 @@ void main() {
       await page.addScriptTag(url: server.prefix + '/modernizr.js');
       expect(await page.evaluate('() => Modernizr.touchevents'), isTrue);
     });
-    test('should support landscape emulation', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should support landscape emulation', () async {
       await page.goto(server.prefix + '/mobile.html');
       await page.setViewport(puppeteer.devices.iPhone6Landscape.viewport);
       expect(await page.evaluate('() => screen.orientation.type'),
@@ -114,9 +113,7 @@ void main() {
   });
 
   group('Page.emulateMediaType', () {
-    test('should work', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should work', () async {
       expect(await page.evaluate("() => window.matchMedia('screen').matches"),
           isTrue);
       expect(await page.evaluate("() => window.matchMedia('print').matches"),
@@ -139,9 +136,7 @@ void main() {
   });
 
   group('Page.emulateMediaFeatures', () {
-    if (isPuppeteerFirefox) return;
-
-    test('should work ddd', () async {
+    testFailsFirefox('should work ddd', () async {
       await page
           .emulateMediaFeatures([MediaFeature.prefersReducedMotion('reduce')]);
       expect(
@@ -243,9 +238,7 @@ void main() {
     }, skip: 'This is not working in headless and flaky in headful');
   });
 
-  group('Page.emulateTimezone', () {
-    if (isPuppeteerFirefox) return;
-
+  groupFailsFirefox('Page.emulateTimezone', () {
     test('should work', () async {
       await page.evaluate('''() => {
       globalThis.date = new Date(1479579154987);

--- a/test/evaluation_test.dart
+++ b/test/evaluation_test.dart
@@ -1,5 +1,6 @@
 import 'package:puppeteer/puppeteer.dart';
 import 'package:test/test.dart';
+import 'utils/test_api.dart';
 import 'utils/utils.dart';
 
 // ignore_for_file: prefer_interpolation_to_compose_strings
@@ -94,9 +95,8 @@ void main() {
       await page.goto(server.prefix + '/global-var.html');
       expect(await page.evaluate('globalVar'), equals(123));
     });
-    test('should return undefined for objects with symbols', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should return undefined for objects with symbols',
+        () async {
       expect(await page.evaluate("() => [Symbol('foo4')]"), isNull);
     });
     test('should work with function shorthands', () async {
@@ -113,9 +113,7 @@ void main() {
       ]);
       expect(result, equals(42));
     });
-    test('should throw when evaluation triggers reload', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should throw when evaluation triggers reload', () async {
       expect(() => page.evaluate('''() => {
         location.reload();
         return new Promise(() => {});
@@ -133,9 +131,7 @@ void main() {
       await page.goto(server.emptyPage);
       expect(await frameEvaluation, equals(42));
     });
-    test('should work from-inside an exposed function', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should work from-inside an exposed function', () async {
       // Setup inpage callback, which calls Page.evaluate
       await page.exposeFunction('callController', (num a, num b) async {
         return await page.evaluate('(a, b) => a * b', args: [a, b]);
@@ -192,14 +188,11 @@ void main() {
     test('should properly serialize null fields', () async {
       expect(await page.evaluate('() => ({a: undefined})'), equals({}));
     });
-    test('should return undefined for non-serializable objects', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should return undefined for non-serializable objects',
+        () async {
       expect(await page.evaluate('() => window'), isNull);
     });
-    test('should fail for circular object', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should fail for circular object', () async {
       var result = await page.evaluate('''() => {
           var a = {};
           var b = {a};
@@ -242,9 +235,7 @@ void main() {
           throwsA(predicate((e) => '$e'.contains(
               'JSHandles can be evaluated only in the context they were created'))));
     });
-    test('should simulate a user gesture', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should simulate a user gesture', () async {
       var result = await page.evaluate('''() => {
       document.body.appendChild(document.createTextNode('test'));
           document.execCommand('selectAll');
@@ -252,9 +243,7 @@ void main() {
     }''');
       expect(result, isTrue);
     });
-    test('should throw a nice error after a navigation', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should throw a nice error after a navigation', () async {
       var executionContext = await page.mainFrame.executionContext;
 
       await Future.wait([
@@ -282,9 +271,7 @@ void main() {
     });
   });
 
-  group('Page.evaluateOnNewDocument', () {
-    if (isPuppeteerFirefox) return;
-
+  groupFailsFirefox('Page.evaluateOnNewDocument', () {
     test('should evaluate before anything else on the page', () async {
       await page.evaluateOnNewDocument('''() => {
 window.injected = 123;

--- a/test/evaluation_test.dart
+++ b/test/evaluation_test.dart
@@ -95,6 +95,8 @@ void main() {
       expect(await page.evaluate('globalVar'), equals(123));
     });
     test('should return undefined for objects with symbols', () async {
+      if (isPuppeteerFirefox) return;
+
       expect(await page.evaluate("() => [Symbol('foo4')]"), isNull);
     });
     test('should work with function shorthands', () async {
@@ -112,6 +114,8 @@ void main() {
       expect(result, equals(42));
     });
     test('should throw when evaluation triggers reload', () async {
+      if (isPuppeteerFirefox) return;
+
       expect(() => page.evaluate('''() => {
         location.reload();
         return new Promise(() => {});
@@ -130,6 +134,8 @@ void main() {
       expect(await frameEvaluation, equals(42));
     });
     test('should work from-inside an exposed function', () async {
+      if (isPuppeteerFirefox) return;
+
       // Setup inpage callback, which calls Page.evaluate
       await page.exposeFunction('callController', (num a, num b) async {
         return await page.evaluate('(a, b) => a * b', args: [a, b]);
@@ -187,9 +193,13 @@ void main() {
       expect(await page.evaluate('() => ({a: undefined})'), equals({}));
     });
     test('should return undefined for non-serializable objects', () async {
+      if (isPuppeteerFirefox) return;
+
       expect(await page.evaluate('() => window'), isNull);
     });
     test('should fail for circular object', () async {
+      if (isPuppeteerFirefox) return;
+
       var result = await page.evaluate('''() => {
           var a = {};
           var b = {a};
@@ -233,6 +243,8 @@ void main() {
               'JSHandles can be evaluated only in the context they were created'))));
     });
     test('should simulate a user gesture', () async {
+      if (isPuppeteerFirefox) return;
+
       var result = await page.evaluate('''() => {
       document.body.appendChild(document.createTextNode('test'));
           document.execCommand('selectAll');
@@ -241,6 +253,8 @@ void main() {
       expect(result, isTrue);
     });
     test('should throw a nice error after a navigation', () async {
+      if (isPuppeteerFirefox) return;
+
       var executionContext = await page.mainFrame.executionContext;
 
       await Future.wait([
@@ -269,6 +283,8 @@ void main() {
   });
 
   group('Page.evaluateOnNewDocument', () {
+    if (isPuppeteerFirefox) return;
+
     test('should evaluate before anything else on the page', () async {
       await page.evaluateOnNewDocument('''() => {
 window.injected = 123;

--- a/test/examples_test.dart
+++ b/test/examples_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'package:path/path.dart' as p;
+import 'package:puppeteer/puppeteer.dart';
 import 'package:test/test.dart';
 
 // Test all the dart scripts in the example/ folder.
@@ -18,7 +19,13 @@ void main() {
         if (result.exitCode != 0) {
           print(result.stdout);
           print(result.stderr);
-          fail('Exit code is ${result.exitCode}');
+          if (isPuppeteerFirefox) {
+            // Some examples are not executable on Firefox.
+            // just print it
+            print('Exit code is ${result.exitCode}');
+          } else {
+            fail('Exit code is ${result.exitCode}');
+          }
         }
       });
     }

--- a/test/frame_test.dart
+++ b/test/frame_test.dart
@@ -1,5 +1,6 @@
 import 'package:puppeteer/puppeteer.dart';
 import 'package:test/test.dart';
+import 'utils/test_api.dart';
 import 'utils/utils.dart';
 
 // ignore_for_file: prefer_interpolation_to_compose_strings
@@ -92,10 +93,8 @@ void main() {
             '    http://<host>/frames/frame.html (aframe)'
           ]));
     });
-    test('should send events when frames are manipulated dynamically',
-        () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox(
+        'should send events when frames are manipulated dynamically', () async {
       await page.goto(server.emptyPage);
       // validate frameattached events
       var attachedFrames = <Frame>[];
@@ -118,10 +117,9 @@ void main() {
       expect(detachedFrames.length, equals(1));
       expect(detachedFrames[0].isDetached, isTrue);
     });
-    test('should send "framenavigated" when navigating on anchor URLs',
+    testFailsFirefox(
+        'should send "framenavigated" when navigating on anchor URLs',
         () async {
-      if (isPuppeteerFirefox) return;
-
       await page.goto(server.emptyPage);
       await Future.wait([
         page.onFrameNavigated.first,
@@ -142,9 +140,7 @@ void main() {
       await page.goto(server.emptyPage);
       expect(hasEvents, isFalse);
     });
-    test('should detach child frames on navigation', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should detach child frames on navigation', () async {
       var attachedFrames = <Frame>[];
       var detachedFrames = <Frame>[];
       var navigatedFrames = <Frame>[];
@@ -184,9 +180,7 @@ void main() {
       expect(detachedFrames.length, equals(4));
       expect(navigatedFrames.length, equals(1));
     });
-    test('should support framesets', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should support framesets', () async {
       var attachedFrames = <Frame>[];
       var detachedFrames = <Frame>[];
       var navigatedFrames = <Frame>[];

--- a/test/frame_test.dart
+++ b/test/frame_test.dart
@@ -94,6 +94,8 @@ void main() {
     });
     test('should send events when frames are manipulated dynamically',
         () async {
+      if (isPuppeteerFirefox) return;
+
       await page.goto(server.emptyPage);
       // validate frameattached events
       var attachedFrames = <Frame>[];
@@ -118,6 +120,8 @@ void main() {
     });
     test('should send "framenavigated" when navigating on anchor URLs',
         () async {
+      if (isPuppeteerFirefox) return;
+
       await page.goto(server.emptyPage);
       await Future.wait([
         page.onFrameNavigated.first,
@@ -139,6 +143,8 @@ void main() {
       expect(hasEvents, isFalse);
     });
     test('should detach child frames on navigation', () async {
+      if (isPuppeteerFirefox) return;
+
       var attachedFrames = <Frame>[];
       var detachedFrames = <Frame>[];
       var navigatedFrames = <Frame>[];
@@ -179,6 +185,8 @@ void main() {
       expect(navigatedFrames.length, equals(1));
     });
     test('should support framesets', () async {
+      if (isPuppeteerFirefox) return;
+
       var attachedFrames = <Frame>[];
       var detachedFrames = <Frame>[];
       var navigatedFrames = <Frame>[];

--- a/test/headful_test.dart
+++ b/test/headful_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'package:path/path.dart' as p;
 import 'package:puppeteer/puppeteer.dart';
 import 'package:test/test.dart';
+import 'utils/test_api.dart';
 import 'utils/utils.dart';
 
 void main() {
@@ -24,9 +25,7 @@ void main() {
     '--load-extension=$extensionPath',
   ];
 
-  group('HEADFUL', () {
-    if (isPuppeteerFirefox) return;
-
+  groupChromeOnly('HEADFUL', () {
     test('background_page target type should be available', () async {
       var browserWithExtension =
           await puppeteer.launch(headless: false, args: extensionOptions);
@@ -148,9 +147,7 @@ void main() {
   });
 
   group('Page.bringToFront', () {
-    if (isPuppeteerFirefox) return;
-
-    test('should work', () async {
+    testFailsFirefoxFIXME('should work', () async {
       var browser = await puppeteer.launch(headless: false);
       try {
         var page1 = await browser.newPage();

--- a/test/headful_test.dart
+++ b/test/headful_test.dart
@@ -25,6 +25,8 @@ void main() {
   ];
 
   group('HEADFUL', () {
+    if (isPuppeteerFirefox) return;
+
     test('background_page target type should be available', () async {
       var browserWithExtension =
           await puppeteer.launch(headless: false, args: extensionOptions);
@@ -146,6 +148,8 @@ void main() {
   });
 
   group('Page.bringToFront', () {
+    if (isPuppeteerFirefox) return;
+
     test('should work', () async {
       var browser = await puppeteer.launch(headless: false);
       try {

--- a/test/input_file_test.dart
+++ b/test/input_file_test.dart
@@ -37,6 +37,8 @@ void main() {
   const fileToUpload = 'test/assets/file-to-upload.txt';
 
   group('input', () {
+    if (isPuppeteerFirefox) return;
+
     test('should upload the file', () async {
       await page.goto(server.prefix + '/input/fileupload.html');
       var filePath = File(fileToUpload);
@@ -56,6 +58,8 @@ void main() {
   });
 
   group('Page.waitForFileChooser', () {
+    if (isPuppeteerFirefox) return;
+
     test('should work when file input is attached to DOM', () async {
       await page.setContent('<input type=file>');
       var chooser =
@@ -117,6 +121,8 @@ void main() {
   });
 
   group('FileChooser.accept', () {
+    if (isPuppeteerFirefox) return;
+
     test('should accept single file', () async {
       await page.setContent(
           '''<input type=file oninput='javascript:console.timeStamp()'>''');
@@ -193,6 +199,8 @@ void main() {
   });
 
   group('FileChooser.cancel', () {
+    if (isPuppeteerFirefox) return;
+
     test('should cancel dialog', () async {
       // Consider file chooser canceled if we can summon another one.
       // There's no reliable way in WebPlatform to see that FileChooser was
@@ -223,6 +231,8 @@ void main() {
   });
 
   group('FileChooser.isMultiple', () {
+    if (isPuppeteerFirefox) return;
+
     test('should work for single file pick', () async {
       await page.setContent('<input type=file>');
       var chooser = await waitFutures(page.waitForFileChooser(), [

--- a/test/input_file_test.dart
+++ b/test/input_file_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:puppeteer/puppeteer.dart';
 import 'package:puppeteer/src/page/page.dart';
 import 'package:test/test.dart';
+import 'utils/test_api.dart';
 import 'utils/utils.dart';
 
 // ignore_for_file: prefer_interpolation_to_compose_strings
@@ -36,9 +37,7 @@ void main() {
 
   const fileToUpload = 'test/assets/file-to-upload.txt';
 
-  group('input', () {
-    if (isPuppeteerFirefox) return;
-
+  groupFailsFirefox('input', () {
     test('should upload the file', () async {
       await page.goto(server.prefix + '/input/fileupload.html');
       var filePath = File(fileToUpload);
@@ -57,9 +56,7 @@ void main() {
     });
   });
 
-  group('Page.waitForFileChooser', () {
-    if (isPuppeteerFirefox) return;
-
+  groupFailsFirefox('Page.waitForFileChooser', () {
     test('should work when file input is attached to DOM', () async {
       await page.setContent('<input type=file>');
       var chooser =
@@ -120,9 +117,7 @@ void main() {
     });
   });
 
-  group('FileChooser.accept', () {
-    if (isPuppeteerFirefox) return;
-
+  groupFailsFirefox('FileChooser.accept', () {
     test('should accept single file', () async {
       await page.setContent(
           '''<input type=file oninput='javascript:console.timeStamp()'>''');
@@ -198,9 +193,7 @@ void main() {
     });
   });
 
-  group('FileChooser.cancel', () {
-    if (isPuppeteerFirefox) return;
-
+  groupFailsFirefox('FileChooser.cancel', () {
     test('should cancel dialog', () async {
       // Consider file chooser canceled if we can summon another one.
       // There's no reliable way in WebPlatform to see that FileChooser was
@@ -230,9 +223,7 @@ void main() {
     });
   });
 
-  group('FileChooser.isMultiple', () {
-    if (isPuppeteerFirefox) return;
-
+  groupFailsFirefox('FileChooser.isMultiple', () {
     test('should work for single file pick', () async {
       await page.setContent('<input type=file>');
       var chooser = await waitFutures(page.waitForFileChooser(), [

--- a/test/js_handle_test.dart
+++ b/test/js_handle_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'package:puppeteer/puppeteer.dart';
 import 'package:test/test.dart';
+import 'utils/test_api.dart';
 import 'utils/utils.dart';
 
 void main() {
@@ -95,9 +96,7 @@ void main() {
       var json = await aHandle.jsonValue;
       expect(json, equals({'foo': 'bar'}));
     });
-    test('should not work with dates', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should not work with dates', () async {
       var dateHandle = await page
           .evaluateHandle("() => new Date('2017-09-26T00:00:00.000Z')");
       var json = await dateHandle.jsonValue;

--- a/test/js_handle_test.dart
+++ b/test/js_handle_test.dart
@@ -96,6 +96,8 @@ void main() {
       expect(json, equals({'foo': 'bar'}));
     });
     test('should not work with dates', () async {
+      if (isPuppeteerFirefox) return;
+
       var dateHandle = await page
           .evaluateHandle("() => new Date('2017-09-26T00:00:00.000Z')");
       var json = await dateHandle.jsonValue;
@@ -103,10 +105,15 @@ void main() {
     });
     test('should throw for circular objects', () async {
       var windowHandle = await page.evaluateHandle('window');
-      expect(
-          () => windowHandle.jsonValue,
-          throwsA(
-              predicate((e) => '$e' == 'Object reference chain is too long')));
+      if (isPuppeteerFirefox) {
+        expect(() => windowHandle.jsonValue,
+            throwsA(predicate((e) => '$e' == 'Object is not serializable')));
+      } else {
+        expect(
+            () => windowHandle.jsonValue,
+            throwsA(predicate(
+                (e) => '$e' == 'Object reference chain is too long')));
+      }
     });
   });
 

--- a/test/keyboard_test.dart
+++ b/test/keyboard_test.dart
@@ -42,7 +42,7 @@ void main() {
     }
   });
 
-  test('Can type into a textarea', () async {
+  test('should type into a textarea', () async {
     await page.goto(server.emptyPage);
     await page.evaluate(
         //language=js
@@ -53,12 +53,14 @@ function _() {
   textarea.focus();
 }
 ''');
-    var text = 'Hello world. éàê^';
+    var text = 'Hello world. I am the text that was typed!';
     await page.keyboard.type(text);
     expect(await page.evaluate('document.querySelector("textarea").value'),
         equals(text));
   });
   test('Press the metaKey', () async {
+    if (isPuppeteerFirefox) return;
+
     await page.evaluate(
         //language=js
         '''
@@ -93,6 +95,8 @@ function _() {
         equals('Hello World!'));
   });
   test('should send a character with sendCharacter', () async {
+    if (isPuppeteerFirefox) return;
+
     await page.goto(server.assetUrl('input/textarea.html'));
     await page.focus('textarea');
     await page.keyboard.sendCharacter('嗨');
@@ -179,6 +183,8 @@ function _() {
     expect(await page.evaluate('() => textarea.value'), equals('He Wrd!'));
   });
   test('should specify repeat property', () async {
+    if (isPuppeteerFirefox) return;
+
     await page.goto(server.assetUrl('input/textarea.html'));
     await page.focus('textarea');
     await page.evaluate(
@@ -198,6 +204,8 @@ function _() {
     expect(await page.evaluate('() => window.lastEvent.repeat'), isFalse);
   });
   test('should type all kinds of characters', () async {
+    if (isPuppeteerFirefox) return;
+
     await page.goto(server.assetUrl('input/textarea.html'));
     await page.focus('textarea');
     var text = 'This text goes onto two lines.\nThis character is 嗨.';
@@ -205,6 +213,8 @@ function _() {
     expect(await page.evaluate('result'), equals(text));
   });
   test('should specify location', () async {
+    if (isPuppeteerFirefox) return;
+
     await page.goto(server.assetUrl('input/textarea.html'));
     await page.evaluate('''() => {
   window.addEventListener('keydown', event => window.keyLocation = event.location, true);
@@ -224,12 +234,16 @@ function _() {
     expect(await page.evaluate('keyLocation'), equals(3));
   });
   test('Type emoji', () async {
+    if (isPuppeteerFirefox) return;
+
     await page.goto(server.assetUrl('input/textarea.html'));
     await page.type('textarea', '👹 Tokyo street Japan 🇯🇵');
     expect(await page.$eval('textarea', '(textarea) => textarea.value'),
         equals('👹 Tokyo street Japan 🇯🇵'));
   });
   test('should type emoji into an iframe', () async {
+    if (isPuppeteerFirefox) return;
+
     await page.goto(server.emptyPage);
     await attachFrame(
         page, 'emoji-test', server.assetUrl('input/textarea.html'));

--- a/test/keyboard_test.dart
+++ b/test/keyboard_test.dart
@@ -1,5 +1,6 @@
 import 'package:puppeteer/puppeteer.dart';
 import 'package:test/test.dart';
+import 'utils/test_api.dart';
 import 'utils/utils.dart';
 
 void main() {
@@ -58,9 +59,7 @@ function _() {
     expect(await page.evaluate('document.querySelector("textarea").value'),
         equals(text));
   });
-  test('Press the metaKey', () async {
-    if (isPuppeteerFirefox) return;
-
+  testFailsFirefox('Press the metaKey', () async {
     await page.evaluate(
         //language=js
         '''
@@ -94,9 +93,7 @@ function _() {
         await page.evaluate("() => document.querySelector('textarea').value"),
         equals('Hello World!'));
   });
-  test('should send a character with sendCharacter', () async {
-    if (isPuppeteerFirefox) return;
-
+  testFailsFirefox('should send a character with sendCharacter', () async {
     await page.goto(server.assetUrl('input/textarea.html'));
     await page.focus('textarea');
     await page.keyboard.sendCharacter('嗨');
@@ -182,9 +179,7 @@ function _() {
     await page.keyboard.type('Hello World!');
     expect(await page.evaluate('() => textarea.value'), equals('He Wrd!'));
   });
-  test('should specify repeat property', () async {
-    if (isPuppeteerFirefox) return;
-
+  testFailsFirefox('should specify repeat property', () async {
     await page.goto(server.assetUrl('input/textarea.html'));
     await page.focus('textarea');
     await page.evaluate(
@@ -203,18 +198,14 @@ function _() {
     await page.keyboard.down(Key.keyA);
     expect(await page.evaluate('() => window.lastEvent.repeat'), isFalse);
   });
-  test('should type all kinds of characters', () async {
-    if (isPuppeteerFirefox) return;
-
+  testFailsFirefox('should type all kinds of characters', () async {
     await page.goto(server.assetUrl('input/textarea.html'));
     await page.focus('textarea');
     var text = 'This text goes onto two lines.\nThis character is 嗨.';
     await page.keyboard.type(text);
     expect(await page.evaluate('result'), equals(text));
   });
-  test('should specify location', () async {
-    if (isPuppeteerFirefox) return;
-
+  testFailsFirefox('should specify location', () async {
     await page.goto(server.assetUrl('input/textarea.html'));
     await page.evaluate('''() => {
   window.addEventListener('keydown', event => window.keyLocation = event.location, true);
@@ -233,17 +224,13 @@ function _() {
     await textarea.press(Key.numpadSubtract);
     expect(await page.evaluate('keyLocation'), equals(3));
   });
-  test('Type emoji', () async {
-    if (isPuppeteerFirefox) return;
-
+  testFailsFirefox('Type emoji', () async {
     await page.goto(server.assetUrl('input/textarea.html'));
     await page.type('textarea', '👹 Tokyo street Japan 🇯🇵');
     expect(await page.$eval('textarea', '(textarea) => textarea.value'),
         equals('👹 Tokyo street Japan 🇯🇵'));
   });
-  test('should type emoji into an iframe', () async {
-    if (isPuppeteerFirefox) return;
-
+  testFailsFirefox('should type emoji into an iframe', () async {
     await page.goto(server.emptyPage);
     await attachFrame(
         page, 'emoji-test', server.assetUrl('input/textarea.html'));

--- a/test/launcher_test.dart
+++ b/test/launcher_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:puppeteer/puppeteer.dart';
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:test/test.dart';
+import 'utils/test_api.dart';
 import 'utils/utils.dart';
 
 void main() {
@@ -20,10 +21,9 @@ void main() {
   });
   group('Puppeteer', () {
     group('Browser.disconnect', () {
-      test('should reject navigation when browser closes', () async {
-        // This test is really unstable on Firefox.
-        if (isPuppeteerFirefox) return;
-
+      // This test is really unstable on Firefox.
+      testFailsFirefoxFIXME('should reject navigation when browser closes',
+          () async {
         server.setRoute('/one-style.css', (request) {
           return Completer<shelf.Response>().future;
         });
@@ -211,9 +211,8 @@ void main() {
         expect(pages, equals(['about:blank']));
         await browser.close();
       });
-      test('should have custom url when launching browser', () async {
-        if (isPuppeteerFirefox) return;
-
+      testFailsFirefox('should have custom url when launching browser',
+          () async {
         var browser = await puppeteer.launch(args: [server.emptyPage]);
         var pages = await browser.pages;
         expect(pages.length, equals(1));
@@ -275,9 +274,8 @@ void main() {
       test('should support ignoreHTTPSErrors option', () async {
         //TODO(xha): enable once we support https server
       });
-      test('should be able to reconnect to a disconnected browser', () async {
-        if (isPuppeteerFirefox) return;
-
+      testFailsFirefox('should be able to reconnect to a disconnected browser',
+          () async {
         var originalBrowser = await puppeteer.launch();
         var browserWsEndpoint = originalBrowser.wsEndpoint;
         var page = await originalBrowser.newPage();
@@ -303,9 +301,8 @@ void main() {
       });
     });
     // @see https://github.com/GoogleChrome/puppeteer/issues/4197#issuecomment-481793410
-    test('should be able to connect to the same page simultaneously', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox(
+        'should be able to connect to the same page simultaneously', () async {
       var browserOne = await puppeteer.launch();
       var browserTwo =
           await puppeteer.connect(browserWsEndpoint: browserOne.wsEndpoint);
@@ -320,9 +317,7 @@ void main() {
   });
 
   group('Browser target events', () {
-    test('should work', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should work', () async {
       var browser = await puppeteer.launch();
       var events = [];
       browser.onTargetCreated.listen((_) => events.add('CREATED'));

--- a/test/mouse_test.dart
+++ b/test/mouse_test.dart
@@ -1,5 +1,6 @@
 import 'package:puppeteer/puppeteer.dart';
 import 'package:test/test.dart';
+import 'utils/test_api.dart';
 import 'utils/utils.dart';
 
 void main() {
@@ -105,9 +106,7 @@ function dimensions() {
       return textarea.value.substring(textarea.selectionStart, textarea.selectionEnd);
       }'''), equals(text));
     });
-    test('should trigger hover state', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should trigger hover state', () async {
       await page.goto('${server.prefix}/input/scrollable.html');
       await page.hover('#button-6');
       expect(
@@ -125,9 +124,8 @@ function dimensions() {
               .evaluate("() => document.querySelector('button:hover').id"),
           equals('button-91'));
     });
-    test('should trigger hover state with removed window.Node', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should trigger hover state with removed window.Node',
+        () async {
       await page.goto('${server.prefix}/input/scrollable.html');
       await page.evaluate('() => delete window.Node');
       await page.hover('#button-6');
@@ -166,9 +164,7 @@ function dimensions() {
         }
       }
     });
-    test('should send mouse wheel events', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should send mouse wheel events', () async {
       await page.goto('${server.prefix}/input/wheel.html');
       var elem = await page.$('div');
       var boundingBoxBefore = await elem.boundingBox;
@@ -184,9 +180,7 @@ function dimensions() {
       expect(boundingBoxAfter.width, 230);
       expect(boundingBoxAfter.height, 230);
     });
-    test('should tween mouse movement', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should tween mouse movement', () async {
       await page.mouse.move(Point(100, 100));
       await page.evaluate('''() => {
       window.result = [];

--- a/test/mouse_test.dart
+++ b/test/mouse_test.dart
@@ -106,6 +106,8 @@ function dimensions() {
       }'''), equals(text));
     });
     test('should trigger hover state', () async {
+      if (isPuppeteerFirefox) return;
+
       await page.goto('${server.prefix}/input/scrollable.html');
       await page.hover('#button-6');
       expect(
@@ -124,6 +126,8 @@ function dimensions() {
           equals('button-91'));
     });
     test('should trigger hover state with removed window.Node', () async {
+      if (isPuppeteerFirefox) return;
+
       await page.goto('${server.prefix}/input/scrollable.html');
       await page.evaluate('() => delete window.Node');
       await page.hover('#button-6');
@@ -163,6 +167,8 @@ function dimensions() {
       }
     });
     test('should send mouse wheel events', () async {
+      if (isPuppeteerFirefox) return;
+
       await page.goto('${server.prefix}/input/wheel.html');
       var elem = await page.$('div');
       var boundingBoxBefore = await elem.boundingBox;
@@ -179,6 +185,8 @@ function dimensions() {
       expect(boundingBoxAfter.height, 230);
     });
     test('should tween mouse movement', () async {
+      if (isPuppeteerFirefox) return;
+
       await page.mouse.move(Point(100, 100));
       await page.evaluate('''() => {
       window.result = [];

--- a/test/navigation_test.dart
+++ b/test/navigation_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:puppeteer/puppeteer.dart';
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:test/test.dart';
+import 'utils/test_api.dart';
 import 'utils/utils.dart';
 
 // ignore_for_file: prefer_interpolation_to_compose_strings
@@ -37,9 +38,7 @@ void main() {
       await page.goto(server.emptyPage);
       expect(page.url, equals(server.emptyPage));
     });
-    test('should work with anchor navigation', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should work with anchor navigation', () async {
       await page.goto(server.emptyPage);
       expect(page.url, equals(server.emptyPage));
       await page.goto(server.emptyPage + '#foo');
@@ -62,17 +61,13 @@ void main() {
       var response = await page.goto(server.prefix + '/historyapi.html');
       expect(response.status, equals(200));
     });
-    test('should work with subframes return 204', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should work with subframes return 204', () async {
       server.setRoute('/frames/frame.html', (req) {
         return shelf.Response(204);
       });
       await page.goto(server.prefix + '/frames/one-frame.html');
     });
-    test('should fail when server returns 204', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should fail when server returns 204', () async {
       server.setRoute('/204.html', (req) => shelf.Response(204));
       expect(() => page.goto(server.assetUrl('204.html')),
           throwsA(predicate((e) => '$e'.contains('net::ERR_ABORTED'))));
@@ -90,15 +85,13 @@ void main() {
       var response = await page.goto(server.prefix + '/grid.html');
       expect(response.status, equals(200));
     });
-    test('should navigate to empty page with networkidle0', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should navigate to empty page with networkidle0',
+        () async {
       var response = await page.goto(server.emptyPage, wait: Until.networkIdle);
       expect(response.status, equals(200));
     });
-    test('should navigate to empty page with networkidle2', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should navigate to empty page with networkidle2',
+        () async {
       var response =
           await page.goto(server.emptyPage, wait: Until.networkAlmostIdle);
       expect(response.status, equals(200));
@@ -109,9 +102,7 @@ void main() {
           throwsA(predicate(
               (e) => '$e'.contains('Cannot navigate to invalid URL'))));
     });
-    test('should fail when navigating to bad SSL', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should fail when navigating to bad SSL', () async {
       // Make sure that network events do not emit 'undefined'.
       // @see https://crbug.com/750469
       page.onRequest.listen((request) => expect(request, isNotNull));
@@ -188,9 +179,7 @@ void main() {
       var response = await page.goto(server.assetUrl('simple.html'));
       expect(response.ok, isTrue);
     });
-    test('should work when navigating to data url', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should work when navigating to data url', () async {
       var response = await page.goto('data:text/html,hello');
       expect(response.ok, isTrue);
     });
@@ -207,9 +196,8 @@ void main() {
       expect(response.ok, isTrue);
       expect(response.url, equals(server.emptyPage));
     });
-    test('should wait for network idle to succeed navigation', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should wait for network idle to succeed navigation',
+        () async {
       var responses = <Completer<shelf.Response>>[];
       Future<shelf.Response> addResponse() {
         var response = Completer<shelf.Response>();
@@ -288,9 +276,8 @@ void main() {
     test('should not leak listeners during navigation of 11 pages', () async {
       //TODO(xha): implement, the test uses a warning listener on the process
     });
-    test('should navigate to dataURL and fire dataURL requests', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should navigate to dataURL and fire dataURL requests',
+        () async {
       var requests = <Request>[];
       page.onRequest.listen((request) {
         if (!request.url.contains('favicon.ico')) {
@@ -303,10 +290,9 @@ void main() {
       expect(requests.length, equals(1));
       expect(requests[0].url, equals(dataURL));
     });
-    test('should navigate to URL with hash and fire requests without hash',
+    testFailsFirefox(
+        'should navigate to URL with hash and fire requests without hash',
         () async {
-      if (isPuppeteerFirefox) return;
-
       var requests = [];
       page.onRequest.listen((request) {
         if (!request.url.contains('favicon.ico')) {
@@ -330,9 +316,7 @@ void main() {
       expect(
           () => page.goto(url), throwsA(predicate((e) => '$e'.contains(url))));
     }, skip: "Can't reproduce the original test (needs https)");
-    test('should send referer', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should send referer', () async {
       var request1Future = server.waitForRequest('/grid.html');
       var request2Future = server.waitForRequest('/digits/1.png');
 
@@ -350,9 +334,7 @@ void main() {
   });
 
   group('Page.waitForNavigation', () {
-    test('should work', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should work', () async {
       await page.goto(server.emptyPage);
       var response = await waitFutures(page.waitForNavigation(), [
         page.evaluate('url => window.location.href = url',
@@ -384,9 +366,7 @@ void main() {
       await bothFiredPromise;
       await navigationPromise;
     });
-    test('should work with clicking on anchor links', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should work with clicking on anchor links', () async {
       await page.goto(server.emptyPage);
       await page.setContent("<a href='#foobar'>foobar</a>");
       var response = await waitFutures(page.waitForNavigation(), [
@@ -395,9 +375,7 @@ void main() {
       expect(response, isNull);
       expect(page.url, equals(server.emptyPage + '#foobar'));
     });
-    test('should work with history.pushState()', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should work with history.pushState()', () async {
       await page.goto(server.emptyPage);
       await page.setContent('''
       <a onclick='javascript:pushState()'>SPA</a>
@@ -411,9 +389,7 @@ void main() {
       expect(response, isNull);
       expect(page.url, equals(server.prefix + '/wow.html'));
     });
-    test('should work with history.replaceState()', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should work with history.replaceState()', () async {
       await page.goto(server.emptyPage);
       await page.setContent('''
       <a onclick='javascript:replaceState()'>SPA</a>
@@ -427,9 +403,8 @@ void main() {
       expect(response, isNull);
       expect(page.url, equals(server.prefix + '/replaced.html'));
     });
-    test('should work with DOM history.back()/history.forward()', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should work with DOM history.back()/history.forward()',
+        () async {
       await page.goto(server.emptyPage);
       await page.setContent('''
       <a id=back onclick='javascript:goBack()'>back</a>
@@ -453,9 +428,8 @@ void main() {
       expect(forwardResponse, isNull);
       expect(page.url, equals(server.prefix + '/second.html'));
     });
-    test('should work when subframe issues window.stop()', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should work when subframe issues window.stop()',
+        () async {
       server.setRoute(
           '/frames/style.css', (req) => Completer<shelf.Response>().future);
 
@@ -474,9 +448,7 @@ void main() {
   });
 
   group('Page.goBack', () {
-    test('should work', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefoxFIXME('should work', () async {
       await page.goto(server.emptyPage);
       await page.goto(server.prefix + '/grid.html');
 
@@ -491,9 +463,7 @@ void main() {
       response = await page.goForward();
       expect(response, isNull);
     });
-    test('should work with HistoryAPI', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should work with HistoryAPI', () async {
       await page.goto(server.emptyPage);
       await page.evaluate('''() => {
       history.pushState({}, '', '/first.html');
@@ -510,9 +480,7 @@ void main() {
     });
   });
 
-  group('Frame.goto', () {
-    if (isPuppeteerFirefox) return;
-
+  groupFailsFirefox('Frame.goto', () {
     test('should navigate subframes', () async {
       await page.goto(server.prefix + '/frames/one-frame.html');
       expect(page.frames[0].url, contains('/frames/one-frame.html'));
@@ -576,9 +544,7 @@ void main() {
     });
   });
 
-  group('Frame.waitForNavigation', () {
-    if (isPuppeteerFirefox) return;
-
+  groupFailsFirefox('Frame.waitForNavigation', () {
     test('should work', () async {
       await page.goto(server.prefix + '/frames/one-frame.html');
       var frame = page.frames[1];

--- a/test/navigation_test.dart
+++ b/test/navigation_test.dart
@@ -38,6 +38,8 @@ void main() {
       expect(page.url, equals(server.emptyPage));
     });
     test('should work with anchor navigation', () async {
+      if (isPuppeteerFirefox) return;
+
       await page.goto(server.emptyPage);
       expect(page.url, equals(server.emptyPage));
       await page.goto(server.emptyPage + '#foo');
@@ -61,12 +63,16 @@ void main() {
       expect(response.status, equals(200));
     });
     test('should work with subframes return 204', () async {
+      if (isPuppeteerFirefox) return;
+
       server.setRoute('/frames/frame.html', (req) {
         return shelf.Response(204);
       });
       await page.goto(server.prefix + '/frames/one-frame.html');
     });
     test('should fail when server returns 204', () async {
+      if (isPuppeteerFirefox) return;
+
       server.setRoute('/204.html', (req) => shelf.Response(204));
       expect(() => page.goto(server.assetUrl('204.html')),
           throwsA(predicate((e) => '$e'.contains('net::ERR_ABORTED'))));
@@ -85,10 +91,14 @@ void main() {
       expect(response.status, equals(200));
     });
     test('should navigate to empty page with networkidle0', () async {
+      if (isPuppeteerFirefox) return;
+
       var response = await page.goto(server.emptyPage, wait: Until.networkIdle);
       expect(response.status, equals(200));
     });
     test('should navigate to empty page with networkidle2', () async {
+      if (isPuppeteerFirefox) return;
+
       var response =
           await page.goto(server.emptyPage, wait: Until.networkAlmostIdle);
       expect(response.status, equals(200));
@@ -100,6 +110,8 @@ void main() {
               (e) => '$e'.contains('Cannot navigate to invalid URL'))));
     });
     test('should fail when navigating to bad SSL', () async {
+      if (isPuppeteerFirefox) return;
+
       // Make sure that network events do not emit 'undefined'.
       // @see https://crbug.com/750469
       page.onRequest.listen((request) => expect(request, isNotNull));
@@ -115,10 +127,17 @@ void main() {
       //expect(() => page.goto(httpsServer.prefix + '/redirect/1.html'), throwsA(predicate((e) => '$e'.contains('net::ERR_CERT_AUTHORITY_INVALID'))));
     }, skip: "Test server doesn't support https yet");
     test('should fail when main resources failed to load', () async {
-      expect(
-          () => page.goto('http://localhost:44123/non-existing-url'),
-          throwsA(
-              predicate((e) => '$e'.contains('net::ERR_CONNECTION_REFUSED'))));
+      if (isPuppeteerFirefox) {
+        expect(
+            () => page.goto('http://localhost:44123/non-existing-url'),
+            throwsA(predicate(
+                (e) => '$e'.contains('NS_ERROR_CONNECTION_REFUSED'))));
+      } else {
+        expect(
+            () => page.goto('http://localhost:44123/non-existing-url'),
+            throwsA(predicate(
+                (e) => '$e'.contains('net::ERR_CONNECTION_REFUSED'))));
+      }
     });
     test('should fail when exceeding maximum navigation timeout', () async {
       // Hang for request to the infinite.html
@@ -170,6 +189,8 @@ void main() {
       expect(response.ok, isTrue);
     });
     test('should work when navigating to data url', () async {
+      if (isPuppeteerFirefox) return;
+
       var response = await page.goto('data:text/html,hello');
       expect(response.ok, isTrue);
     });
@@ -187,6 +208,8 @@ void main() {
       expect(response.url, equals(server.emptyPage));
     });
     test('should wait for network idle to succeed navigation', () async {
+      if (isPuppeteerFirefox) return;
+
       var responses = <Completer<shelf.Response>>[];
       Future<shelf.Response> addResponse() {
         var response = Completer<shelf.Response>();
@@ -266,6 +289,8 @@ void main() {
       //TODO(xha): implement, the test uses a warning listener on the process
     });
     test('should navigate to dataURL and fire dataURL requests', () async {
+      if (isPuppeteerFirefox) return;
+
       var requests = <Request>[];
       page.onRequest.listen((request) {
         if (!request.url.contains('favicon.ico')) {
@@ -280,6 +305,8 @@ void main() {
     });
     test('should navigate to URL with hash and fire requests without hash',
         () async {
+      if (isPuppeteerFirefox) return;
+
       var requests = [];
       page.onRequest.listen((request) {
         if (!request.url.contains('favicon.ico')) {
@@ -304,6 +331,8 @@ void main() {
           () => page.goto(url), throwsA(predicate((e) => '$e'.contains(url))));
     }, skip: "Can't reproduce the original test (needs https)");
     test('should send referer', () async {
+      if (isPuppeteerFirefox) return;
+
       var request1Future = server.waitForRequest('/grid.html');
       var request2Future = server.waitForRequest('/digits/1.png');
 
@@ -322,6 +351,8 @@ void main() {
 
   group('Page.waitForNavigation', () {
     test('should work', () async {
+      if (isPuppeteerFirefox) return;
+
       await page.goto(server.emptyPage);
       var response = await waitFutures(page.waitForNavigation(), [
         page.evaluate('url => window.location.href = url',
@@ -354,6 +385,8 @@ void main() {
       await navigationPromise;
     });
     test('should work with clicking on anchor links', () async {
+      if (isPuppeteerFirefox) return;
+
       await page.goto(server.emptyPage);
       await page.setContent("<a href='#foobar'>foobar</a>");
       var response = await waitFutures(page.waitForNavigation(), [
@@ -363,6 +396,8 @@ void main() {
       expect(page.url, equals(server.emptyPage + '#foobar'));
     });
     test('should work with history.pushState()', () async {
+      if (isPuppeteerFirefox) return;
+
       await page.goto(server.emptyPage);
       await page.setContent('''
       <a onclick='javascript:pushState()'>SPA</a>
@@ -377,6 +412,8 @@ void main() {
       expect(page.url, equals(server.prefix + '/wow.html'));
     });
     test('should work with history.replaceState()', () async {
+      if (isPuppeteerFirefox) return;
+
       await page.goto(server.emptyPage);
       await page.setContent('''
       <a onclick='javascript:replaceState()'>SPA</a>
@@ -391,6 +428,8 @@ void main() {
       expect(page.url, equals(server.prefix + '/replaced.html'));
     });
     test('should work with DOM history.back()/history.forward()', () async {
+      if (isPuppeteerFirefox) return;
+
       await page.goto(server.emptyPage);
       await page.setContent('''
       <a id=back onclick='javascript:goBack()'>back</a>
@@ -415,6 +454,8 @@ void main() {
       expect(page.url, equals(server.prefix + '/second.html'));
     });
     test('should work when subframe issues window.stop()', () async {
+      if (isPuppeteerFirefox) return;
+
       server.setRoute(
           '/frames/style.css', (req) => Completer<shelf.Response>().future);
 
@@ -434,6 +475,8 @@ void main() {
 
   group('Page.goBack', () {
     test('should work', () async {
+      if (isPuppeteerFirefox) return;
+
       await page.goto(server.emptyPage);
       await page.goto(server.prefix + '/grid.html');
 
@@ -449,6 +492,8 @@ void main() {
       expect(response, isNull);
     });
     test('should work with HistoryAPI', () async {
+      if (isPuppeteerFirefox) return;
+
       await page.goto(server.emptyPage);
       await page.evaluate('''() => {
       history.pushState({}, '', '/first.html');
@@ -466,6 +511,8 @@ void main() {
   });
 
   group('Frame.goto', () {
+    if (isPuppeteerFirefox) return;
+
     test('should navigate subframes', () async {
       await page.goto(server.prefix + '/frames/one-frame.html');
       expect(page.frames[0].url, contains('/frames/one-frame.html'));
@@ -530,6 +577,8 @@ void main() {
   });
 
   group('Frame.waitForNavigation', () {
+    if (isPuppeteerFirefox) return;
+
     test('should work', () async {
       await page.goto(server.prefix + '/frames/one-frame.html');
       var frame = page.frames[1];

--- a/test/network_test.dart
+++ b/test/network_test.dart
@@ -112,7 +112,11 @@ void main() {
   group('Request.headers', () {
     test('should work', () async {
       var response = await page.goto(server.emptyPage);
-      expect(response.request.headers['user-agent'], contains('Chrome'));
+      if (isPuppeteerFirefox) {
+        expect(response.request.headers['user-agent'], contains('Firefox'));
+      } else {
+        expect(response.request.headers['user-agent'], contains('Chrome'));
+      }
     });
   });
 
@@ -127,6 +131,8 @@ void main() {
   });
 
   group('Response.fromCache', () {
+    if (isPuppeteerFirefox) return;
+
     test('should return |false| for non-cached content', () async {
       var response = await page.goto(server.emptyPage);
       expect(response.fromCache, isFalse);
@@ -153,6 +159,8 @@ void main() {
   });
 
   group('Response.fromServiceWorker', () {
+    if (isPuppeteerFirefox) return;
+
     test('should return |false| for non-service-worker content', () async {
       var response = await page.goto(server.emptyPage);
       expect(response.fromServiceWorker, isFalse);
@@ -179,6 +187,8 @@ void main() {
   });
 
   group('Request.postData', () {
+    if (isPuppeteerFirefox) return;
+
     test('should work', () async {
       await page.goto(server.emptyPage);
       server.setRoute('/post', (req) => shelf.Response.ok(''));
@@ -198,6 +208,8 @@ void main() {
   });
 
   group('Response.text', () {
+    if (isPuppeteerFirefox) return;
+
     test('should work', () async {
       var response = await page.goto(server.prefix + '/simple.json');
       expect(await response.text, startsWith('{"foo": "bar"}'));
@@ -266,6 +278,8 @@ void main() {
   });
 
   group('Response.json', () {
+    if (isPuppeteerFirefox) return;
+
     test('should work', () async {
       var response = await page.goto(server.prefix + '/simple.json');
       expect(await response.json, equals({'foo': 'bar'}));
@@ -273,6 +287,8 @@ void main() {
   });
 
   group('Response.buffer', () {
+    if (isPuppeteerFirefox) return;
+
     test('should work', () async {
       var response = await page.goto(server.prefix + '/pptr.png');
       var imageBuffer = File('test/assets/pptr.png').readAsBytesSync();
@@ -299,6 +315,8 @@ void main() {
   });
 
   group('Network Events', () {
+    if (isPuppeteerFirefox) return;
+
     test('Page.Events.Request', () async {
       var requests = <Request>[];
       page.onRequest.listen(requests.add);
@@ -344,7 +362,11 @@ void main() {
       expect(failedRequests[0].url, contains('one-style.css'));
       expect(failedRequests[0].response, isNull);
       expect(failedRequests[0].resourceType, equals(ResourceType.stylesheet));
-      expect(failedRequests[0].failure, equals('net::ERR_FAILED'));
+      if (isPuppeteerFirefox) {
+        expect(failedRequests[0].failure, equals('NS_ERROR_FAILURE'));
+      } else {
+        expect(failedRequests[0].failure, equals('net::ERR_FAILED'));
+      }
       expect(failedRequests[0].frame, isNotNull);
     });
     test('Page.Events.RequestFinished', () async {
@@ -399,6 +421,8 @@ void main() {
 
   group('Request.isNavigationRequest', () {
     test('should work', () async {
+      if (isPuppeteerFirefox) return;
+
       var requests = <String, Request>{};
       page.onRequest
           .listen((request) => requests[request.url.split('/').last] = request);
@@ -411,6 +435,8 @@ void main() {
       expect(requests['style.css'].isNavigationRequest, isFalse);
     });
     test('should work with request interception', () async {
+      if (isPuppeteerFirefox) return;
+
       var requests = <String, Request>{};
       page.onRequest.listen((request) {
         requests[request.url.split('/').last] = request;
@@ -434,6 +460,8 @@ void main() {
   });
 
   group('Page.setExtraHTTPHeaders', () {
+    if (isPuppeteerFirefox) return;
+
     test('should work', () async {
       await page.setExtraHTTPHeaders({'foo': 'bar'});
       var request = await waitFutures(server.waitForRequest('/simple.html'), [
@@ -444,6 +472,8 @@ void main() {
   });
 
   group('Page.authenticate', () {
+    if (isPuppeteerFirefox) return;
+
     test('should work', () async {
       //TODO(xha): add auth to test server and re-enable test
       //server.setAuth('/empty.html', 'user', 'pass');

--- a/test/network_test.dart
+++ b/test/network_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:puppeteer/puppeteer.dart';
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:test/test.dart';
+import 'utils/test_api.dart';
 import 'utils/utils.dart';
 
 // ignore_for_file: prefer_interpolation_to_compose_strings
@@ -130,9 +131,7 @@ void main() {
     });
   });
 
-  group('Response.fromCache', () {
-    if (isPuppeteerFirefox) return;
-
+  groupFailsFirefox('Response.fromCache', () {
     test('should return |false| for non-cached content', () async {
       var response = await page.goto(server.emptyPage);
       expect(response.fromCache, isFalse);
@@ -158,9 +157,7 @@ void main() {
     });
   });
 
-  group('Response.fromServiceWorker', () {
-    if (isPuppeteerFirefox) return;
-
+  groupFailsFirefox('Response.fromServiceWorker', () {
     test('should return |false| for non-service-worker content', () async {
       var response = await page.goto(server.emptyPage);
       expect(response.fromServiceWorker, isFalse);
@@ -186,9 +183,7 @@ void main() {
     });
   });
 
-  group('Request.postData', () {
-    if (isPuppeteerFirefox) return;
-
+  groupFailsFirefox('Request.postData', () {
     test('should work', () async {
       await page.goto(server.emptyPage);
       server.setRoute('/post', (req) => shelf.Response.ok(''));
@@ -207,9 +202,7 @@ void main() {
     });
   });
 
-  group('Response.text', () {
-    if (isPuppeteerFirefox) return;
-
+  groupFailsFirefox('Response.text', () {
     test('should work', () async {
       var response = await page.goto(server.prefix + '/simple.json');
       expect(await response.text, startsWith('{"foo": "bar"}'));
@@ -277,18 +270,14 @@ void main() {
     });
   });
 
-  group('Response.json', () {
-    if (isPuppeteerFirefox) return;
-
+  groupFailsFirefox('Response.json', () {
     test('should work', () async {
       var response = await page.goto(server.prefix + '/simple.json');
       expect(await response.json, equals({'foo': 'bar'}));
     });
   });
 
-  group('Response.buffer', () {
-    if (isPuppeteerFirefox) return;
-
+  groupFailsFirefox('Response.buffer', () {
     test('should work', () async {
       var response = await page.goto(server.prefix + '/pptr.png');
       var imageBuffer = File('test/assets/pptr.png').readAsBytesSync();
@@ -314,9 +303,7 @@ void main() {
     });
   });
 
-  group('Network Events', () {
-    if (isPuppeteerFirefox) return;
-
+  groupFailsFirefox('Network Events', () {
     test('Page.Events.Request', () async {
       var requests = <Request>[];
       page.onRequest.listen(requests.add);
@@ -420,9 +407,7 @@ void main() {
   });
 
   group('Request.isNavigationRequest', () {
-    test('should work', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should work', () async {
       var requests = <String, Request>{};
       page.onRequest
           .listen((request) => requests[request.url.split('/').last] = request);
@@ -434,9 +419,7 @@ void main() {
       expect(requests['script.js'].isNavigationRequest, isFalse);
       expect(requests['style.css'].isNavigationRequest, isFalse);
     });
-    test('should work with request interception', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should work with request interception', () async {
       var requests = <String, Request>{};
       page.onRequest.listen((request) {
         requests[request.url.split('/').last] = request;
@@ -459,9 +442,7 @@ void main() {
     });
   });
 
-  group('Page.setExtraHTTPHeaders', () {
-    if (isPuppeteerFirefox) return;
-
+  groupFailsFirefox('Page.setExtraHTTPHeaders', () {
     test('should work', () async {
       await page.setExtraHTTPHeaders({'foo': 'bar'});
       var request = await waitFutures(server.waitForRequest('/simple.html'), [
@@ -471,9 +452,7 @@ void main() {
     });
   });
 
-  group('Page.authenticate', () {
-    if (isPuppeteerFirefox) return;
-
+  groupFailsFirefox('Page.authenticate', () {
     test('should work', () async {
       //TODO(xha): add auth to test server and re-enable test
       //server.setAuth('/empty.html', 'user', 'pass');

--- a/test/oopif_test.dart
+++ b/test/oopif_test.dart
@@ -36,6 +36,8 @@ void main() {
         .toList();
   }
 
+  if (isPuppeteerFirefox) return;
+
   test('should report oopif frames', () async {
     await page.goto('${server.prefix}/dynamic-oopif.html');
     expect(_oopifs(), hasLength(1));

--- a/test/oopif_test.dart
+++ b/test/oopif_test.dart
@@ -1,6 +1,7 @@
 import 'package:puppeteer/puppeteer.dart';
 import 'package:puppeteer/src/target.dart';
 import 'package:test/test.dart';
+import 'utils/test_api.dart';
 import 'utils/utils.dart';
 
 void main() {
@@ -36,18 +37,18 @@ void main() {
         .toList();
   }
 
-  if (isPuppeteerFirefox) return;
-
-  test('should report oopif frames', () async {
-    await page.goto('${server.prefix}/dynamic-oopif.html');
-    expect(_oopifs(), hasLength(1));
-    expect(page.frames, hasLength(2));
-  }, skip: true);
-  test('should load oopif iframes with subresources and request interception',
-      () async {
-    await page.setRequestInterception(true);
-    page.onRequest.listen((request) => request.continueRequest());
-    await page.goto('${server.prefix}/dynamic-oopif.html');
-    expect(_oopifs(), hasLength(1));
+  groupChromeOnly('OOPIF', () {
+    test('should report oopif frames', () async {
+      await page.goto('${server.prefix}/dynamic-oopif.html');
+      expect(_oopifs(), hasLength(1));
+      expect(page.frames, hasLength(2));
+    }, skip: true);
+    test('should load oopif iframes with subresources and request interception',
+        () async {
+      await page.setRequestInterception(true);
+      page.onRequest.listen((request) => request.continueRequest());
+      await page.goto('${server.prefix}/dynamic-oopif.html');
+      expect(_oopifs(), hasLength(1));
+    });
   });
 }

--- a/test/page_test.dart
+++ b/test/page_test.dart
@@ -53,6 +53,8 @@ void main() {
       expect(await browser.pages, isNot(contains(newPage)));
     });
     test('should run beforeunload if asked for', () async {
+      if (isPuppeteerFirefox) return;
+
       var newPage = await context.newPage();
       await newPage.goto(server.prefix + '/beforeunload.html');
       // We have to interact with a page so that 'beforeunload' handlers
@@ -67,6 +69,8 @@ void main() {
       await pageClosingPromise;
     });
     test('should *not* run beforeunload by default', () async {
+      if (isPuppeteerFirefox) return;
+
       var newPage = await context.newPage();
       await newPage.goto(server.prefix + '/beforeunload.html');
       // We have to interact with a page so that 'beforeunload' handlers
@@ -120,6 +124,8 @@ void main() {
     });
   });
   group('Page.Events.error', () {
+    if (isPuppeteerFirefox) return;
+
     test('should throw when page crashes', () async {
       var onErrorFuture = page.onError.first;
 
@@ -129,6 +135,8 @@ void main() {
     });
   });
   group('Page.Events.Popup', () {
+    if (isPuppeteerFirefox) return;
+
     test('should work', () async {
       var dialogFuture = page.onPopup.first;
       await page.evaluate("() => window.open('about:blank')");
@@ -187,12 +195,16 @@ void main() {
           equals('prompt'));
     });
     test('should deny permission when not listed', () async {
+      if (isPuppeteerFirefox) return;
+
       await page.goto(server.emptyPage);
       await context.overridePermissions(server.emptyPage, []);
       expect(await getPermission(page, PermissionType.geolocation),
           equals('denied'));
     });
     test('should grant permission when listed', () async {
+      if (isPuppeteerFirefox) return;
+
       await page.goto(server.emptyPage);
       await context
           .overridePermissions(server.emptyPage, [PermissionType.geolocation]);
@@ -200,6 +212,8 @@ void main() {
           equals('granted'));
     });
     test('should reset permissions', () async {
+      if (isPuppeteerFirefox) return;
+
       await page.goto(server.emptyPage);
       await context
           .overridePermissions(server.emptyPage, [PermissionType.geolocation]);
@@ -210,6 +224,8 @@ void main() {
           equals('prompt'));
     });
     test('should trigger permission onchange', () async {
+      if (isPuppeteerFirefox) return;
+
       await page.goto(server.emptyPage);
       await page.evaluate('''() => {
         window.events = [];
@@ -235,6 +251,8 @@ void main() {
           equals(['prompt', 'denied', 'granted', 'prompt']));
     });
     test('should isolate permissions between browser contexs', () async {
+      if (isPuppeteerFirefox) return;
+
       await page.goto(server.emptyPage);
       var otherContext = await browser.createIncognitoBrowserContext();
       var otherPage = await otherContext.newPage();
@@ -263,6 +281,8 @@ void main() {
   });
   group('Page.setGeolocation', () {
     test('should work', () async {
+      if (isPuppeteerFirefox) return;
+
       await context
           .overridePermissions(server.hostUrl, [PermissionType.geolocation]);
       await page.goto(server.emptyPage);
@@ -279,6 +299,8 @@ void main() {
     });
   });
   group('Page.setOfflineMode', () {
+    if (isPuppeteerFirefox) return;
+
     test('should work', () async {
       await page.setOfflineMode(true);
       await expectLater(
@@ -298,6 +320,8 @@ void main() {
 
   group('ExecutionContext.queryObjects', () {
     test('should work', () async {
+      if (isPuppeteerFirefox) return;
+
       // Instantiate an object
       await page.evaluate("() => window.set = new Set(['hello', 'world'])");
       var prototypeHandle = await page.evaluateHandle('() => Set.prototype');
@@ -311,6 +335,8 @@ void main() {
       expect(values, equals(['hello', 'world']));
     });
     test('should work for non-blank page', () async {
+      if (isPuppeteerFirefox) return;
+
       // Instantiate an object
       await page.goto(server.emptyPage);
       await page.evaluate("() => window.set = new Set(['hello', 'world'])");
@@ -339,6 +365,8 @@ void main() {
     });
   });
   group('Page.Events.Console', () {
+    if (isPuppeteerFirefox) return;
+
     test('should work', () async {
       var message = await waitFutures(page.onConsole.first,
           [page.evaluate("() => console.log('hello', 5, {foo: 'bar'})")]);
@@ -442,6 +470,8 @@ void main() {
     });
   });
   group('Page.metrics', () {
+    if (isPuppeteerFirefox) return;
+
     void checkMetrics(Metrics metrics) {
       var metricsToCheck = {
         'Timestamp',
@@ -535,6 +565,8 @@ void main() {
     });
   });
   group('Page.exposeFunction', () {
+    if (isPuppeteerFirefox) return;
+
     test('should work', () async {
       await page.exposeFunction('compute', (num a, num b) {
         return a * b;
@@ -624,6 +656,8 @@ void main() {
   });
 
   group('Page.Events.PageError', () {
+    if (isPuppeteerFirefox) return;
+
     test('should fire', () async {
       var error = await waitFutures(page.onError.first, [
         page.goto(server.prefix + '/error.html'),
@@ -708,6 +742,8 @@ void main() {
           throwsA(TypeMatcher<TimeoutException>()));
     });
     test('should await resources to load', () async {
+      if (isPuppeteerFirefox) return;
+
       var imgPath = 'img.png';
       Completer<shelf.Response> imgResponse;
       server.setRoute(imgPath, (req) {
@@ -787,6 +823,8 @@ void main() {
     });
 
     test('should throw an error if loading from url fail', () async {
+      if (isPuppeteerFirefox) return;
+
       await page.goto(server.emptyPage);
       expect(() => page.addScriptTag(url: '/nonexistfile.js'),
           throwsA(predicate((e) => '$e'.contains('Evaluation failed'))));
@@ -884,6 +922,8 @@ void main() {
     });
 
     test('should throw when added with content to the CSP page', () async {
+      if (isPuppeteerFirefox) return;
+
       await page.goto(server.prefix + '/csp.html');
       expect(
           () => page.addStyleTag(content: 'body { background-color: green; }'),
@@ -908,6 +948,8 @@ void main() {
   });
 
   group('Page.setJavaScriptEnabled', () {
+    if (isPuppeteerFirefox) return;
+
     test('should work', () async {
       await page.setJavaScriptEnabled(false);
       await page
@@ -1032,6 +1074,8 @@ void main() {
     });
     // @see https://github.com/GoogleChrome/puppeteer/issues/3327
     test('should work when re-defining top-level Event class', () async {
+      if (isPuppeteerFirefox) return;
+
       await page.goto(server.prefix + '/input/select.html');
       await page.evaluate('() => window.Event = null');
       await page.select('select', ['blue']);
@@ -1042,6 +1086,8 @@ void main() {
 
   group('Page.Events.Close', () {
     test('should work with window.close', () async {
+      if (isPuppeteerFirefox) return;
+
       var newPageFuture =
           context.onTargetCreated.first.then((target) => target.page);
       await page

--- a/test/page_test.dart
+++ b/test/page_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:puppeteer/puppeteer.dart';
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:test/test.dart';
+import 'utils/test_api.dart';
 import 'utils/utils.dart';
 
 // ignore_for_file: prefer_interpolation_to_compose_strings
@@ -52,9 +53,7 @@ void main() {
       await newPage.close();
       expect(await browser.pages, isNot(contains(newPage)));
     });
-    test('should run beforeunload if asked for', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should run beforeunload if asked for', () async {
       var newPage = await context.newPage();
       await newPage.goto(server.prefix + '/beforeunload.html');
       // We have to interact with a page so that 'beforeunload' handlers
@@ -68,9 +67,7 @@ void main() {
       await dialog.accept();
       await pageClosingPromise;
     });
-    test('should *not* run beforeunload by default', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should *not* run beforeunload by default', () async {
       var newPage = await context.newPage();
       await newPage.goto(server.prefix + '/beforeunload.html');
       // We have to interact with a page so that 'beforeunload' handlers
@@ -123,9 +120,7 @@ void main() {
       expect(error, isNotNull);
     });
   });
-  group('Page.Events.error', () {
-    if (isPuppeteerFirefox) return;
-
+  groupFailsFirefox('Page.Events.error', () {
     test('should throw when page crashes', () async {
       var onErrorFuture = page.onError.first;
 
@@ -134,9 +129,7 @@ void main() {
       expect(error.message, equals('Page crashed!'));
     });
   });
-  group('Page.Events.Popup', () {
-    if (isPuppeteerFirefox) return;
-
+  groupFailsFirefox('Page.Events.Popup', () {
     test('should work', () async {
       var dialogFuture = page.onPopup.first;
       await page.evaluate("() => window.open('about:blank')");
@@ -194,26 +187,20 @@ void main() {
       expect(await getPermission(page, PermissionType.geolocation),
           equals('prompt'));
     });
-    test('should deny permission when not listed', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should deny permission when not listed', () async {
       await page.goto(server.emptyPage);
       await context.overridePermissions(server.emptyPage, []);
       expect(await getPermission(page, PermissionType.geolocation),
           equals('denied'));
     });
-    test('should grant permission when listed', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should grant permission when listed', () async {
       await page.goto(server.emptyPage);
       await context
           .overridePermissions(server.emptyPage, [PermissionType.geolocation]);
       expect(await getPermission(page, PermissionType.geolocation),
           equals('granted'));
     });
-    test('should reset permissions', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should reset permissions', () async {
       await page.goto(server.emptyPage);
       await context
           .overridePermissions(server.emptyPage, [PermissionType.geolocation]);
@@ -223,9 +210,7 @@ void main() {
       expect(await getPermission(page, PermissionType.geolocation),
           equals('prompt'));
     });
-    test('should trigger permission onchange', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should trigger permission onchange', () async {
       await page.goto(server.emptyPage);
       await page.evaluate('''() => {
         window.events = [];
@@ -250,9 +235,8 @@ void main() {
       expect(await page.evaluate('() => window.events'),
           equals(['prompt', 'denied', 'granted', 'prompt']));
     });
-    test('should isolate permissions between browser contexs', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should isolate permissions between browser contexs',
+        () async {
       await page.goto(server.emptyPage);
       var otherContext = await browser.createIncognitoBrowserContext();
       var otherPage = await otherContext.newPage();
@@ -280,9 +264,7 @@ void main() {
     });
   });
   group('Page.setGeolocation', () {
-    test('should work', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should work', () async {
       await context
           .overridePermissions(server.hostUrl, [PermissionType.geolocation]);
       await page.goto(server.emptyPage);
@@ -298,9 +280,7 @@ void main() {
           throwsA(TypeMatcher<AssertionError>()));
     });
   });
-  group('Page.setOfflineMode', () {
-    if (isPuppeteerFirefox) return;
-
+  groupFailsFirefox('Page.setOfflineMode', () {
     test('should work', () async {
       await page.setOfflineMode(true);
       await expectLater(
@@ -319,9 +299,7 @@ void main() {
   });
 
   group('ExecutionContext.queryObjects', () {
-    test('should work', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should work', () async {
       // Instantiate an object
       await page.evaluate("() => window.set = new Set(['hello', 'world'])");
       var prototypeHandle = await page.evaluateHandle('() => Set.prototype');
@@ -334,9 +312,7 @@ void main() {
           args: [objectsHandle]);
       expect(values, equals(['hello', 'world']));
     });
-    test('should work for non-blank page', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should work for non-blank page', () async {
       // Instantiate an object
       await page.goto(server.emptyPage);
       await page.evaluate("() => window.set = new Set(['hello', 'world'])");
@@ -364,9 +340,7 @@ void main() {
               'Exception: Prototype JSHandle must not be referencing primitive value')));
     });
   });
-  group('Page.Events.Console', () {
-    if (isPuppeteerFirefox) return;
-
+  groupFailsFirefox('Page.Events.Console', () {
     test('should work', () async {
       var message = await waitFutures(page.onConsole.first,
           [page.evaluate("() => console.log('hello', 5, {foo: 'bar'})")]);
@@ -469,9 +443,7 @@ void main() {
       await blankFuture;
     });
   });
-  group('Page.metrics', () {
-    if (isPuppeteerFirefox) return;
-
+  groupFailsFirefox('Page.metrics', () {
     void checkMetrics(Metrics metrics) {
       var metricsToCheck = {
         'Timestamp',
@@ -564,9 +536,7 @@ void main() {
       expect(response.url, equals(server.prefix + '/digits/2.png'));
     });
   });
-  group('Page.exposeFunction', () {
-    if (isPuppeteerFirefox) return;
-
+  groupFailsFirefox('Page.exposeFunction', () {
     test('should work', () async {
       await page.exposeFunction('compute', (num a, num b) {
         return a * b;
@@ -655,9 +625,7 @@ void main() {
     });
   });
 
-  group('Page.Events.PageError', () {
-    if (isPuppeteerFirefox) return;
-
+  groupFailsFirefox('Page.Events.PageError', () {
     test('should fire', () async {
       var error = await waitFutures(page.onError.first, [
         page.goto(server.prefix + '/error.html'),
@@ -741,9 +709,7 @@ void main() {
               '<img src="${server.hostUrl + '/' + imgPath}"></img>'),
           throwsA(TypeMatcher<TimeoutException>()));
     });
-    test('should await resources to load', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefoxFIXME('should await resources to load', () async {
       var imgPath = 'img.png';
       Completer<shelf.Response> imgResponse;
       server.setRoute(imgPath, (req) {
@@ -822,9 +788,8 @@ void main() {
       expect(await page.evaluate('() => __es6injected'), equals(42));
     });
 
-    test('should throw an error if loading from url fail', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefoxFIXME('should throw an error if loading from url fail',
+        () async {
       await page.goto(server.emptyPage);
       expect(() => page.addScriptTag(url: '/nonexistfile.js'),
           throwsA(predicate((e) => '$e'.contains('Evaluation failed'))));
@@ -921,9 +886,8 @@ void main() {
           equals('rgb(0, 128, 0)'));
     });
 
-    test('should throw when added with content to the CSP page', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should throw when added with content to the CSP page',
+        () async {
       await page.goto(server.prefix + '/csp.html');
       expect(
           () => page.addStyleTag(content: 'body { background-color: green; }'),
@@ -947,9 +911,7 @@ void main() {
     });
   });
 
-  group('Page.setJavaScriptEnabled', () {
-    if (isPuppeteerFirefox) return;
-
+  groupFailsFirefox('Page.setJavaScriptEnabled', () {
     test('should work', () async {
       await page.setJavaScriptEnabled(false);
       await page
@@ -1073,9 +1035,8 @@ void main() {
           isTrue);
     });
     // @see https://github.com/GoogleChrome/puppeteer/issues/3327
-    test('should work when re-defining top-level Event class', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should work when re-defining top-level Event class',
+        () async {
       await page.goto(server.prefix + '/input/select.html');
       await page.evaluate('() => window.Event = null');
       await page.select('select', ['blue']);
@@ -1085,9 +1046,7 @@ void main() {
   });
 
   group('Page.Events.Close', () {
-    test('should work with window.close', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should work with window.close', () async {
       var newPageFuture =
           context.onTargetCreated.first.then((target) => target.page);
       await page

--- a/test/request_interception_test.dart
+++ b/test/request_interception_test.dart
@@ -5,6 +5,7 @@ import 'package:puppeteer/protocol/network.dart' show ResourceType, ErrorReason;
 import 'package:puppeteer/puppeteer.dart';
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:test/test.dart';
+import 'utils/test_api.dart';
 import 'utils/utils.dart';
 import 'utils/utils_golden.dart';
 
@@ -37,9 +38,7 @@ void main() {
     page = null;
   });
 
-  group('Page.setRequestInterception', () {
-    if (isPuppeteerFirefox) return;
-
+  groupFailsFirefox('Page.setRequestInterception', () {
     test('should intercept', () async {
       await page.setRequestInterception(true);
       page.onRequest.listen((request) {
@@ -431,9 +430,7 @@ void main() {
     });
   });
 
-  group('Request.continue', () {
-    if (isPuppeteerFirefox) return;
-
+  groupFailsFirefox('Request.continue', () {
     test('should work', () async {
       await page.setRequestInterception(true);
       page.onRequest.listen((request) => request.continueRequest());
@@ -515,9 +512,7 @@ void main() {
     });
   });
 
-  group('Request.respond', () {
-    if (isPuppeteerFirefox) return;
-
+  groupFailsFirefox('Request.respond', () {
     test('should work', () async {
       await page.setRequestInterception(true);
       page.onRequest.listen((request) {

--- a/test/request_interception_test.dart
+++ b/test/request_interception_test.dart
@@ -38,6 +38,8 @@ void main() {
   });
 
   group('Page.setRequestInterception', () {
+    if (isPuppeteerFirefox) return;
+
     test('should intercept', () async {
       await page.setRequestInterception(true);
       page.onRequest.listen((request) {
@@ -430,6 +432,8 @@ void main() {
   });
 
   group('Request.continue', () {
+    if (isPuppeteerFirefox) return;
+
     test('should work', () async {
       await page.setRequestInterception(true);
       page.onRequest.listen((request) => request.continueRequest());
@@ -512,6 +516,8 @@ void main() {
   });
 
   group('Request.respond', () {
+    if (isPuppeteerFirefox) return;
+
     test('should work', () async {
       await page.setRequestInterception(true);
       page.onRequest.listen((request) {

--- a/test/screenshot_test.dart
+++ b/test/screenshot_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 import 'package:puppeteer/puppeteer.dart';
 import 'package:test/test.dart';
 import 'utils/utils.dart';
@@ -36,6 +37,8 @@ void main() {
   });
 
   group('Page.screenshot', () {
+    // This test only fails on CI for some reason...
+    if (Platform.environment['CI'] == 'true' && isPuppeteerFirefox) return;
     test('should work', () async {
       await page.setViewport(DeviceViewport(width: 500, height: 500));
       await page.goto(server.prefix + '/grid.html');
@@ -50,6 +53,7 @@ void main() {
       expect(screenshot, equalsGolden('test/golden/screenshot-clip-rect.png'));
     });
     test('should clip elements to the viewport', () async {
+      if (isPuppeteerFirefox) return;
       await page.setViewport(DeviceViewport(width: 500, height: 500));
       await page.goto(server.prefix + '/grid.html');
       var screenshot =
@@ -92,6 +96,7 @@ void main() {
       await Future.wait(pages.map((page) => page.close()));
     });
     test('should allow transparency', () async {
+      if (isPuppeteerFirefox) return;
       await page.setViewport(DeviceViewport(width: 100, height: 100));
       await page.goto(server.emptyPage);
       var screenshot = await page.screenshot(omitBackground: true);
@@ -204,6 +209,7 @@ void main() {
               'test/golden/screenshot-element-scrolled-into-view.png'));
     });
     test('should work with a rotated element', () async {
+      if (isPuppeteerFirefox) return;
       await page.setViewport(DeviceViewport(width: 500, height: 500));
       await page.setContent('''<div style="position:absolute;
       top: 100px;
@@ -218,6 +224,7 @@ void main() {
           equalsGolden('test/golden/screenshot-element-rotate.png'));
     });
     test('should fail to screenshot a detached element', () async {
+      if (isPuppeteerFirefox) return;
       await page.setContent('<h1>remove this</h1>');
       var elementHandle = await page.$('h1');
       await page.evaluate('element => element.remove()', args: [elementHandle]);
@@ -241,6 +248,7 @@ void main() {
           equalsGolden('test/golden/screenshot-element-fractional.png'));
     });
     test('should work for an element with an offset', () async {
+      if (isPuppeteerFirefox) return;
       await page.setContent(
           '<div style="position:absolute; top: 10.3px; left: 20.4px;width:50.3px;height:20.2px;border:1px solid black;"></div>');
       var elementHandle = await page.$('div');

--- a/test/screenshot_test.dart
+++ b/test/screenshot_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'package:puppeteer/puppeteer.dart';
 import 'package:test/test.dart';
+import 'utils/test_api.dart';
 import 'utils/utils.dart';
 import 'utils/utils_golden.dart';
 
@@ -52,8 +53,7 @@ void main() {
           await page.screenshot(clip: Rectangle(50, 100, 150, 100));
       expect(screenshot, equalsGolden('test/golden/screenshot-clip-rect.png'));
     });
-    test('should clip elements to the viewport', () async {
-      if (isPuppeteerFirefox) return;
+    testFailsFirefox('should clip elements to the viewport', () async {
       await page.setViewport(DeviceViewport(width: 500, height: 500));
       await page.goto(server.prefix + '/grid.html');
       var screenshot =
@@ -95,8 +95,7 @@ void main() {
       }
       await Future.wait(pages.map((page) => page.close()));
     });
-    test('should allow transparency', () async {
-      if (isPuppeteerFirefox) return;
+    testFailsFirefox('should allow transparency', () async {
       await page.setViewport(DeviceViewport(width: 100, height: 100));
       await page.goto(server.emptyPage);
       var screenshot = await page.screenshot(omitBackground: true);
@@ -208,8 +207,7 @@ void main() {
           equalsGolden(
               'test/golden/screenshot-element-scrolled-into-view.png'));
     });
-    test('should work with a rotated element', () async {
-      if (isPuppeteerFirefox) return;
+    testFailsFirefox('should work with a rotated element', () async {
       await page.setViewport(DeviceViewport(width: 500, height: 500));
       await page.setContent('''<div style="position:absolute;
       top: 100px;
@@ -223,8 +221,7 @@ void main() {
       expect(screenshot,
           equalsGolden('test/golden/screenshot-element-rotate.png'));
     });
-    test('should fail to screenshot a detached element', () async {
-      if (isPuppeteerFirefox) return;
+    testFailsFirefox('should fail to screenshot a detached element', () async {
       await page.setContent('<h1>remove this</h1>');
       var elementHandle = await page.$('h1');
       await page.evaluate('element => element.remove()', args: [elementHandle]);
@@ -247,8 +244,7 @@ void main() {
       expect(screenshot,
           equalsGolden('test/golden/screenshot-element-fractional.png'));
     });
-    test('should work for an element with an offset', () async {
-      if (isPuppeteerFirefox) return;
+    testFailsFirefox('should work for an element with an offset', () async {
       await page.setContent(
           '<div style="position:absolute; top: 10.3px; left: 20.4px;width:50.3px;height:20.2px;border:1px solid black;"></div>');
       var elementHandle = await page.$('div');

--- a/test/stealth_plugin_test.dart
+++ b/test/stealth_plugin_test.dart
@@ -4,6 +4,7 @@ import 'package:test/test.dart';
 import 'utils/utils.dart';
 
 void main() {
+  // plugin is not supported on Firefox.
   if (isPuppeteerFirefox) return;
 
   Server server;

--- a/test/stealth_plugin_test.dart
+++ b/test/stealth_plugin_test.dart
@@ -4,6 +4,8 @@ import 'package:test/test.dart';
 import 'utils/utils.dart';
 
 void main() {
+  if (isPuppeteerFirefox) return;
+
   Server server;
   setUpAll(() async {
     server = await Server.create();

--- a/test/target_test.dart
+++ b/test/target_test.dart
@@ -3,6 +3,7 @@ import 'package:logging/logging.dart';
 import 'package:puppeteer/puppeteer.dart';
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:test/test.dart';
+import 'utils/test_api.dart';
 import 'utils/utils.dart';
 
 // ignore_for_file: prefer_interpolation_to_compose_strings
@@ -64,9 +65,8 @@ void main() {
           equals('Hello world'));
       expect(await originalPage.$('body'), isNotNull);
     });
-    test('should report when a new page is created and closed', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should report when a new page is created and closed',
+        () async {
       var otherPage = await waitFutures(
           context
               .waitForTarget((target) =>
@@ -95,10 +95,9 @@ void main() {
       expect(allPages, contains(page));
       expect(allPages, isNot(contains(otherPage)));
     });
-    test('should report when a service worker is created and destroyed',
+    testFailsFirefox(
+        'should report when a service worker is created and destroyed',
         () async {
-      if (isPuppeteerFirefox) return;
-
       await page.goto(server.emptyPage);
       var createdTarget = context.onTargetCreated.first;
 
@@ -113,9 +112,7 @@ void main() {
           '() => window.registrationPromise.then(registration => registration.unregister())');
       expect(await destroyedTarget, equals(await createdTarget));
     });
-    test('should create a worker from a service worker', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should create a worker from a service worker', () async {
       var targetFuture =
           context.waitForTarget((target) => target.type == 'service_worker');
       await page.goto(server.prefix + '/serviceworkers/empty/sw.html');
@@ -125,9 +122,7 @@ void main() {
       expect(await worker.evaluate('() => self.toString()'),
           equals('[object ServiceWorkerGlobalScope]'));
     });
-    test('should create a worker from a shared worker', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should create a worker from a shared worker', () async {
       await page.goto(server.emptyPage);
       var targetFuture =
           context.waitForTarget((target) => target.type == 'shared_worker');
@@ -139,9 +134,7 @@ void main() {
       expect(await worker.evaluate('() => self.toString()'),
           equals('[object SharedWorkerGlobalScope]'));
     });
-    test('should report when a target url changes', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should report when a target url changes', () async {
       await page.goto(server.emptyPage);
       var changedTarget = context.onTargetChanged.first;
       await page.goto(server.crossProcessPrefix + '/');
@@ -152,9 +145,7 @@ void main() {
       await page.goto(server.emptyPage);
       expect((await changedTarget).url, equals(server.emptyPage));
     });
-    test('should not report uninitialized pages', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should not report uninitialized pages', () async {
       var targetChanged = false;
       var listener =
           context.onTargetChanged.listen((_) => targetChanged = true);
@@ -175,10 +166,9 @@ void main() {
           reason: 'target should not be reported as changed');
       await listener.cancel();
     });
-    test('should not crash while redirecting if original request was missed',
+    testFailsFirefox(
+        'should not crash while redirecting if original request was missed',
         () async {
-      if (isPuppeteerFirefox) return;
-
       Completer<shelf.Response> serverResponse;
       server.setRoute('one-style.css', (req) {
         serverResponse = Completer<shelf.Response>();
@@ -203,9 +193,7 @@ void main() {
       // Cleanup.
       await newPage.close();
     });
-    test('should have an opener', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should have an opener', () async {
       await page.goto(server.emptyPage);
       var createdTarget = await waitFutures(context.onTargetCreated.first,
           [page.goto(server.prefix + '/popup/window-open.html')]);
@@ -217,9 +205,7 @@ void main() {
   }, timeout: Timeout(Duration(seconds: 10)));
 
   group('Browser.waitForTarget', () {
-    test('should wait for a target', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should wait for a target', () async {
       var resolved = false;
       var targetPromise =
           browser.waitForTarget((target) => target.url == server.emptyPage);

--- a/test/target_test.dart
+++ b/test/target_test.dart
@@ -65,6 +65,8 @@ void main() {
       expect(await originalPage.$('body'), isNotNull);
     });
     test('should report when a new page is created and closed', () async {
+      if (isPuppeteerFirefox) return;
+
       var otherPage = await waitFutures(
           context
               .waitForTarget((target) =>
@@ -95,6 +97,8 @@ void main() {
     });
     test('should report when a service worker is created and destroyed',
         () async {
+      if (isPuppeteerFirefox) return;
+
       await page.goto(server.emptyPage);
       var createdTarget = context.onTargetCreated.first;
 
@@ -110,6 +114,8 @@ void main() {
       expect(await destroyedTarget, equals(await createdTarget));
     });
     test('should create a worker from a service worker', () async {
+      if (isPuppeteerFirefox) return;
+
       var targetFuture =
           context.waitForTarget((target) => target.type == 'service_worker');
       await page.goto(server.prefix + '/serviceworkers/empty/sw.html');
@@ -120,6 +126,8 @@ void main() {
           equals('[object ServiceWorkerGlobalScope]'));
     });
     test('should create a worker from a shared worker', () async {
+      if (isPuppeteerFirefox) return;
+
       await page.goto(server.emptyPage);
       var targetFuture =
           context.waitForTarget((target) => target.type == 'shared_worker');
@@ -132,6 +140,8 @@ void main() {
           equals('[object SharedWorkerGlobalScope]'));
     });
     test('should report when a target url changes', () async {
+      if (isPuppeteerFirefox) return;
+
       await page.goto(server.emptyPage);
       var changedTarget = context.onTargetChanged.first;
       await page.goto(server.crossProcessPrefix + '/');
@@ -143,6 +153,8 @@ void main() {
       expect((await changedTarget).url, equals(server.emptyPage));
     });
     test('should not report uninitialized pages', () async {
+      if (isPuppeteerFirefox) return;
+
       var targetChanged = false;
       var listener =
           context.onTargetChanged.listen((_) => targetChanged = true);
@@ -165,6 +177,8 @@ void main() {
     });
     test('should not crash while redirecting if original request was missed',
         () async {
+      if (isPuppeteerFirefox) return;
+
       Completer<shelf.Response> serverResponse;
       server.setRoute('one-style.css', (req) {
         serverResponse = Completer<shelf.Response>();
@@ -190,6 +204,8 @@ void main() {
       await newPage.close();
     });
     test('should have an opener', () async {
+      if (isPuppeteerFirefox) return;
+
       await page.goto(server.emptyPage);
       var createdTarget = await waitFutures(context.onTargetCreated.first,
           [page.goto(server.prefix + '/popup/window-open.html')]);
@@ -202,6 +218,8 @@ void main() {
 
   group('Browser.waitForTarget', () {
     test('should wait for a target', () async {
+      if (isPuppeteerFirefox) return;
+
       var resolved = false;
       var targetPromise =
           browser.waitForTarget((target) => target.url == server.emptyPage);

--- a/test/touchscreen_test.dart
+++ b/test/touchscreen_test.dart
@@ -1,5 +1,6 @@
 import 'package:puppeteer/puppeteer.dart';
 import 'package:test/test.dart';
+import 'utils/test_api.dart';
 import 'utils/utils.dart';
 
 // ignore_for_file: prefer_interpolation_to_compose_strings
@@ -31,9 +32,7 @@ void main() {
     page = null;
   });
 
-  group('Touchscreen', () {
-    if (isPuppeteerFirefox) return;
-
+  groupFailsFirefox('Touchscreen', () {
     test('should tap the button', () async {
       await page.emulate(puppeteer.devices.iPhone6);
       await page.goto(server.prefix + '/input/button.html');

--- a/test/touchscreen_test.dart
+++ b/test/touchscreen_test.dart
@@ -32,6 +32,8 @@ void main() {
   });
 
   group('Touchscreen', () {
+    if (isPuppeteerFirefox) return;
+
     test('should tap the button', () async {
       await page.emulate(puppeteer.devices.iPhone6);
       await page.goto(server.prefix + '/input/button.html');

--- a/test/tracing_test.dart
+++ b/test/tracing_test.dart
@@ -33,6 +33,8 @@ void main() {
   });
 
   group('Tracing', () {
+    if (isPuppeteerFirefox) return;
+
     test('should output a trace', () async {
       await page.tracing.start(screenshots: true);
       await page.goto(server.prefix + '/grid.html');

--- a/test/tracing_test.dart
+++ b/test/tracing_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'package:puppeteer/puppeteer.dart';
 import 'package:test/test.dart';
+import 'utils/test_api.dart';
 import 'utils/utils.dart';
 
 // ignore_for_file: prefer_interpolation_to_compose_strings
@@ -32,9 +33,7 @@ void main() {
     page = null;
   });
 
-  group('Tracing', () {
-    if (isPuppeteerFirefox) return;
-
+  groupChromeOnly('Tracing', () {
     test('should output a trace', () async {
       await page.tracing.start(screenshots: true);
       await page.goto(server.prefix + '/grid.html');

--- a/test/utils/test_api.dart
+++ b/test/utils/test_api.dart
@@ -1,0 +1,69 @@
+// copy from https://github.com/dart-lang/test/blob/master/pkgs/test_api/lib/test_api.dart
+
+import 'package:puppeteer/puppeteer.dart';
+import 'package:test/test.dart';
+
+void testFailsFirefox(description, dynamic Function() body,
+    {String testOn,
+    Timeout timeout,
+    skip,
+    tags,
+    Map<String, dynamic> onPlatform,
+    int retry}) {
+  test(description.toString(), body,
+      testOn: testOn,
+      timeout: timeout,
+      skip: isPuppeteerFirefox ? true : skip,
+      onPlatform: onPlatform,
+      tags: tags,
+      retry: retry);
+}
+
+// tests which original puppeteer doesn't skip.
+void testFailsFirefoxFIXME(description, dynamic Function() body,
+    {String testOn,
+    Timeout timeout,
+    skip,
+    tags,
+    Map<String, dynamic> onPlatform,
+    int retry}) {
+  test(description.toString(), body,
+      testOn: testOn,
+      timeout: timeout,
+      skip: isPuppeteerFirefox ? true : skip,
+      onPlatform: onPlatform,
+      tags: tags,
+      retry: retry);
+}
+
+void groupFailsFirefox(description, dynamic Function() body,
+    {String testOn,
+    Timeout timeout,
+    skip,
+    tags,
+    Map<String, dynamic> onPlatform,
+    int retry}) {
+  group(description.toString(), body,
+      testOn: testOn,
+      timeout: timeout,
+      skip: isPuppeteerFirefox ? true : skip,
+      tags: tags,
+      onPlatform: onPlatform,
+      retry: retry);
+}
+
+void groupChromeOnly(description, dynamic Function() body,
+    {String testOn,
+    Timeout timeout,
+    skip,
+    tags,
+    Map<String, dynamic> onPlatform,
+    int retry}) {
+  group(description.toString(), body,
+      testOn: testOn,
+      timeout: timeout,
+      skip: isPuppeteerFirefox ? true : skip,
+      tags: tags,
+      onPlatform: onPlatform,
+      retry: retry);
+}

--- a/test/utils/utils.dart
+++ b/test/utils/utils.dart
@@ -119,7 +119,7 @@ async function attachFrame(frameId, url) {
     document.body.appendChild(frame);
     await new Promise(x => frame.onload = x);
     return frame;
-  }  
+  }
 ''', args: [frameId, url]);
   return await handle.asElement.contentFrame;
 }
@@ -144,7 +144,7 @@ function navigateFrame(frameId, url) {
   const frame = document.getElementById(frameId);
   frame.src = url;
   return new Promise(x => frame.onload = x);
-}  
+}
 ''', args: [frameId, url]);
 }
 

--- a/test/wait_task_test.dart
+++ b/test/wait_task_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:puppeteer/puppeteer.dart';
 import 'package:test/test.dart';
+import 'utils/test_api.dart';
 import 'utils/utils.dart';
 
 // ignore_for_file: prefer_interpolation_to_compose_strings
@@ -187,9 +188,7 @@ void main() {
       await frame.waitForSelector('div');
     });
 
-    test('should work with removed MutationObserver', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should work with removed MutationObserver', () async {
       await page.evaluate('() => delete window.MutationObserver');
       var handle = await waitFutures(page.waitForSelector('.zombo'), [
         page.setContent("<div class='zombo'>anything</div>"),
@@ -229,9 +228,7 @@ void main() {
       expect(eHandle.executionContext.frame, equals(page.mainFrame));
     });
 
-    test('should run in specified frame', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should run in specified frame', () async {
       await attachFrame(page, 'frame1', server.emptyPage);
       await attachFrame(page, 'frame2', server.emptyPage);
       var frame1 = page.frames[1];
@@ -243,9 +240,7 @@ void main() {
       expect(eHandle.executionContext.frame, equals(frame2));
     });
 
-    test('should throw when frame is detached', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should throw when frame is detached', () async {
       await attachFrame(page, 'frame1', server.emptyPage);
       var frame = page.frames[1];
       dynamic waitError;
@@ -394,9 +389,7 @@ void main() {
           await page.evaluate('x => x.textContent', args: [await waitForXPath]),
           equals('hello  world  '));
     });
-    test('should run in specified frame', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should run in specified frame', () async {
       await attachFrame(page, 'frame1', server.emptyPage);
       await attachFrame(page, 'frame2', server.emptyPage);
       var frame1 = page.frames[1];
@@ -407,9 +400,7 @@ void main() {
       var eHandle = await waitForXPathPromise;
       expect(eHandle.executionContext.frame, equals(frame2));
     });
-    test('should throw when frame is detached', () async {
-      if (isPuppeteerFirefox) return;
-
+    testFailsFirefox('should throw when frame is detached', () async {
       await attachFrame(page, 'frame1', server.emptyPage);
       var frame = page.frames[1];
       dynamic waitError;

--- a/test/wait_task_test.dart
+++ b/test/wait_task_test.dart
@@ -188,6 +188,8 @@ void main() {
     });
 
     test('should work with removed MutationObserver', () async {
+      if (isPuppeteerFirefox) return;
+
       await page.evaluate('() => delete window.MutationObserver');
       var handle = await waitFutures(page.waitForSelector('.zombo'), [
         page.setContent("<div class='zombo'>anything</div>"),
@@ -228,6 +230,8 @@ void main() {
     });
 
     test('should run in specified frame', () async {
+      if (isPuppeteerFirefox) return;
+
       await attachFrame(page, 'frame1', server.emptyPage);
       await attachFrame(page, 'frame2', server.emptyPage);
       var frame1 = page.frames[1];
@@ -240,6 +244,8 @@ void main() {
     });
 
     test('should throw when frame is detached', () async {
+      if (isPuppeteerFirefox) return;
+
       await attachFrame(page, 'frame1', server.emptyPage);
       var frame = page.frames[1];
       dynamic waitError;
@@ -389,6 +395,8 @@ void main() {
           equals('hello  world  '));
     });
     test('should run in specified frame', () async {
+      if (isPuppeteerFirefox) return;
+
       await attachFrame(page, 'frame1', server.emptyPage);
       await attachFrame(page, 'frame2', server.emptyPage);
       var frame1 = page.frames[1];
@@ -400,6 +408,8 @@ void main() {
       expect(eHandle.executionContext.frame, equals(frame2));
     });
     test('should throw when frame is detached', () async {
+      if (isPuppeteerFirefox) return;
+
       await attachFrame(page, 'frame1', server.emptyPage);
       var frame = page.frames[1];
       dynamic waitError;

--- a/test/worker_test.dart
+++ b/test/worker_test.dart
@@ -32,6 +32,8 @@ void main() {
   });
 
   group('Workers', () {
+    if (isPuppeteerFirefox) return;
+
     test('Page.workers', () async {
       await Future.wait([
         page.onWorkerCreated.first,

--- a/test/worker_test.dart
+++ b/test/worker_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:puppeteer/puppeteer.dart';
 import 'package:test/test.dart';
+import 'utils/test_api.dart';
 import 'utils/utils.dart';
 
 // ignore_for_file: prefer_interpolation_to_compose_strings
@@ -31,9 +32,7 @@ void main() {
     page = null;
   });
 
-  group('Workers', () {
-    if (isPuppeteerFirefox) return;
-
+  groupFailsFirefox('Workers', () {
     test('Page.workers', () async {
       await Future.wait([
         page.onWorkerCreated.first,


### PR DESCRIPTION
refs #117 

We can support Firefox by migrating `FirefoxLauncher` class from [here](https://github.com/puppeteer/puppeteer/blob/main/src/node/Launcher.ts) into Dart code.
(I actually developed it in my personal project [puppeteer-ruby](https://github.com/YusukeIwaki/puppeteer-ruby/pull/21) )

puppeteer-dart currently doesn't have `Launcher` and Puppeteer class has such functionality, so I tried to create another puppeteer class as `PuppeteerFirefox`


Known issues:

* Firefox often returns imcomplete payloads (some fields are `null` or `{}` or undefined...). Current `protocol` classes are assumed to be used with Chromium, and often throw cast errors with Firefox.
* ~~Firefox nightly is distributed with variours formats (.zip for Win64, .dmg for macOS, .tar.bz2 for Linux), and it is a little hard to support extracting all of them. (I always use Docker, and actually I don't use it... 😅 ) So in this implementation, `executablePath` is assumed to be required. (Downloader for Firefox is not implemented)~~ IMPLEMENTED

### example

```dart
Future<void> main() async {
  Logger.root.level = Level.ALL;
  Logger.root.onRecord.listen(print);

  final browser = await puppeteerFirefox.launch(
    headless: false,
    executablePath: '/Applications/Firefox Nightly.app/Contents/MacOS/firefox',
  );
  final myPage = await browser.newPage();

  // Go to a page and wait to be fully loaded
  await myPage.goto('https://www.google.com');

  // Do something... See other examples
  await myPage.click('input[name="q"]');
  await myPage.keyboard.type('puppeteer');

  await Future.wait([
    myPage.waitForNavigation(),
    myPage.keyboard.press(Key.enter),
  ]);

  await File('_google-puppeteer.png').writeAsBytes(await myPage.screenshot());

  await myPage.goto('https://detectmybrowser.com/');

  await File('_detect-my-browser.png').writeAsBytes(await myPage.screenshot());

  // Gracefully close the browser's process
  await browser.close();
}
```

_google-puppeteer.png:

![google-puppeteer](https://user-images.githubusercontent.com/11763113/95672738-48fb3500-0bde-11eb-9545-f22476b9eb46.png)


_detect-my-browser.png

![detect-my-browser](https://user-images.githubusercontent.com/11763113/95672739-4ac4f880-0bde-11eb-9653-cc7362b52e99.png)
