### PR TITLE
Add _eventController check in Connection._onMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 1.20.1 (2020-10-14)
+- Fix `Browser.close()` error
+
 # 1.20.0 (2020-09-11)
 - Update Chromium to version 86
 

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -95,6 +95,7 @@ class Connection implements Client {
     if (_delay != null) {
       await Future.delayed(_delay);
     }
+    if (_eventController.isClosed) return;
 
     var object = jsonDecode(message) as Map<String, dynamic>;
     var id = object['id'] as int;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: puppeteer
 description: A high-level API to control headless Chrome over the DevTools Protocol. This is a port of Puppeteer in Dart.
-version: 1.20.0
+version: 1.20.1
 homepage: https://github.com/xvrh/puppeteer-dart
 
 environment:


### PR DESCRIPTION
### Problem / Feature
When calling Browser.close() we were encountering the below error:

```
Bad state: Cannot add new events after calling close
2020-10-12T21:24:10.863732935Z   dart:async                                                        _BroadcastStreamController.add
2020-10-12T21:24:10.863993642Z   package:puppeteer/src/connection.dart 146:24                      Connection._onMessage
2020-10-12T21:24:10.863998503Z   ===== asynchronous gap ===========================
2020-10-12T21:24:10.864001234Z   dart:async                                                        _asyncThenWrapperHelper
2020-10-12T21:24:10.864004050Z   package:puppeteer/src/connection.dart                             Connection._onMessage
2020-10-12T21:24:10.864006811Z   ===== asynchronous gap ===========================
2020-10-12T21:24:10.864009873Z   dart:_internal                                                    CastStream.listen
2020-10-12T21:24:10.864020954Z   package:puppeteer/src/connection.dart 44:40                       new Connection._
2020-10-12T21:24:10.864024376Z   package:puppeteer/src/connection.dart 58:23                       Connection.create
2020-10-12T21:24:10.864027017Z   ===== asynchronous gap ===========================
2020-10-12T21:24:10.864029476Z   dart:async                                                        _asyncThenWrapperHelper
2020-10-12T21:24:10.864031999Z   package:puppeteer/src/connection.dart                             Connection.create
2020-10-12T21:24:10.864034785Z   package:puppeteer/src/puppeteer.dart 173:41                       Puppeteer.launch
2020-10-12T21:24:10.864037390Z   ===== asynchronous gap ===========================
2020-10-12T21:24:10.864039800Z   dart:async                                                        _asyncThenWrapperHelper
2020-10-12T21:24:10.864042402Z   package:puppeteer/src/puppeteer.dart                              Puppeteer.launch
```

### Solution
Added another `isClosed` check near the beginning of Connection._onMessage

### Semantic Versioning
- [ ] The following public APIs were changed in a non-backward compatible way, this requires a major version bump:
  - *[link to the API(s) in the diff]*
- [ ] New feature or public API changed in backward compatible way, this requires a minor version bump
- [x] No public API changes nor new features (backwards-compatible refactor or bug fix), so this can be included in a patch release
  
