### PR TITLE
Throw exception if selector fails to find element

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -624,6 +624,7 @@ await subscription.cancel();
 
 #### page.$(String selector)
 The method runs `document.querySelector` within the page. If no element matches the selector, it throws an exception.
+If you know that no element may match use `$OrNull(selector)` which will return `null` if no element matches the selector.
 
 Shortcut for [Page.mainFrame.$(selector)].
 
@@ -3318,7 +3319,7 @@ ElementHandle instances can be used as arguments in [page.$eval] and
 
 #### elementHandle.$(String selector)
 The method runs `element.querySelector` within the page. If no element
-matches the selector, the return value resolves to `null`.
+matches the selector, an exception is thrown.
 
 ```dart
 elementHandle.$(String selector) → Future<ElementHandle> 

--- a/lib/src/page/js_handle.dart
+++ b/lib/src/page/js_handle.dart
@@ -569,9 +569,15 @@ async function _(element, pageJavascriptEnabled) {
   }
 
   /// The method runs `element.querySelector` within the page. If no element
-  /// matches the selector, the return value resolves to `null`.
+  /// matches the selector, an exception is thrown.
   Future<ElementHandle> $(String selector) async {
-    return $OrNull(selector).then((e) => e!);
+    return $OrNull(selector).then((e) {
+      if (e == null) {
+        throw Exception(
+            'Error: failed to find element matching selector "$selector"');
+      }
+      return e;
+    });
   }
 
   Future<ElementHandle?> $OrNull(String selector) async {

--- a/lib/src/page/page.dart
+++ b/lib/src/page/page.dart
@@ -509,6 +509,7 @@ class Page {
   }
 
   /// The method runs `document.querySelector` within the page. If no element matches the selector, it throws an exception.
+  /// If you know that no element may match use `$OrNull(selector)` which will return `null` if no element matches the selector.
   ///
   /// Shortcut for [Page.mainFrame.$(selector)].
   ///


### PR DESCRIPTION
To address #139 I added a comment to make the new `$OrNull` call more visible. Also throwing a custom exception if the selector would return null instead of darts default exception.