### PR TITLE
make defaultViewport nullable in puppeteer.connect()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.2.1 (2021-07-12
+- Make `defaultViewport` nullable in the `connect` method.
+
 ## 2.2.0 (2021-06-4)
 - Update Chromium to version 92
 - Add drag-and-drop support

--- a/doc/api.md
+++ b/doc/api.md
@@ -273,7 +273,7 @@ Parameters:
     Useful so that you can see what is going on.
 
 ```dart
-puppeteer.connect({String? browserWsEndpoint, String? browserUrl, DeviceViewport defaultViewport = LaunchOptions.viewportNotSpecified, bool? ignoreHttpsErrors, Duration? slowMo, List<Plugin>? plugins}) → Future<Browser> 
+puppeteer.connect({String? browserWsEndpoint, String? browserUrl, DeviceViewport? defaultViewport = LaunchOptions.viewportNotSpecified, bool? ignoreHttpsErrors, Duration? slowMo, List<Plugin>? plugins}) → Future<Browser> 
 ```
 
 #### puppeteer.launch(...)

--- a/lib/src/puppeteer.dart
+++ b/lib/src/puppeteer.dart
@@ -213,7 +213,7 @@ class Puppeteer {
   Future<Browser> connect(
       {String? browserWsEndpoint,
       String? browserUrl,
-      DeviceViewport defaultViewport = LaunchOptions.viewportNotSpecified,
+      DeviceViewport? defaultViewport = LaunchOptions.viewportNotSpecified,
       bool? ignoreHttpsErrors,
       Duration? slowMo,
       List<Plugin>? plugins}) async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: puppeteer
 description: A high-level API to control headless Chrome over the DevTools Protocol. This is a port of Puppeteer in Dart.
-version: 2.2.0
+version: 2.2.1
 homepage: https://github.com/xvrh/puppeteer-dart
 
 environment:


### PR DESCRIPTION
I wanted to use the default viewport size, but leaving the default option of LaunchOptions.viewportNotSpecified still overrides the viewport since DeviceViewport() is called which has defaults of 1280*1024, and LaunchOptions.viewportNotOverride throws the exception "Width and height values must be positive, not greater than 10000000", which makes sense since it is just DeviceViewport(width: -2). Making the defaultViewport nullable and setting to null works in my case and uses the default viewport.