### PR TITLE
Fixes incorrect browser path resolution on windows

### DIFF
--- a/lib/src/browser_path.dart
+++ b/lib/src/browser_path.dart
@@ -47,7 +47,7 @@ List<String> _windowsPaths(String folder) {
   ]) {
     var env = Platform.environment[envName];
     if (env != null) {
-      paths.add(p.join(env, '\\Google\\$folder\\Application\\chrome.exe'));
+      paths.add(p.join(env, 'Google\\$folder\\Application\\chrome.exe'));
     }
   }
   return paths;


### PR DESCRIPTION
Before this fix, the `path.join` returns a path of `C:\Google\Chrome\Application\chrome.exe` due to the prefixed `\\`, by removing it the path is correctly resolved relative to the directory.