### PR TITLE
Fix page.waitForSelector('#selector', timeout: Duration.zero) throws instantly instead of disabling timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.20.0
+- Fixed a bug: `page.waitForSelector('#selector', timeout: Duration.zero)` throws instantly instead of disabling timeout #210.
+- Internal refactor of target management to use auto discover feature of Chromium.
+
 ## 2.19.0
 - Update to Chromium 109
 - Adds a setter for the TargetInfo type

--- a/lib/src/page/dom_world.dart
+++ b/lib/src/page/dom_world.dart
@@ -416,7 +416,7 @@ class WaitTask {
   final List? predicateArgs;
   final _completer = Completer<JsHandle>();
   int _runCount = 0;
-  late Timer _timeoutTimer;
+  Timer? _timeoutTimer;
   bool _terminated = false;
 
   WaitTask(this.domWorld, @Language('js') this.predicate,
@@ -490,7 +490,7 @@ class WaitTask {
   }
 
   void _cleanup() {
-    _timeoutTimer.cancel();
+    _timeoutTimer?.cancel();
     domWorld._waitTasks.remove(this);
   }
 }

--- a/lib/src/page/dom_world.dart
+++ b/lib/src/page/dom_world.dart
@@ -426,12 +426,13 @@ class WaitTask {
       required this.predicateArgs}) {
     domWorld._waitTasks.add(this);
 
+    var timeout = this.timeout;
     // Since page navigation requires us to re-install the pageScript, we should track
     // timeout on our end.
-    if (timeout != null) {
+    if (timeout != null && timeout.inMicroseconds > 0) {
       var timeoutError = TimeoutException(
-          'waiting for $title failed: timeout ${timeout!.inMilliseconds}ms exceeded');
-      _timeoutTimer = Timer(timeout!, () => terminate(timeoutError));
+          'waiting for $title failed: timeout ${timeout.inMilliseconds}ms exceeded');
+      _timeoutTimer = Timer(timeout, () => terminate(timeoutError));
     }
     rerun();
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: puppeteer
 description: A high-level API to control headless Chrome over the DevTools Protocol. This is a port of Puppeteer in Dart.
-version: 2.19.0
+version: 2.20.0
 homepage: https://github.com/xvrh/puppeteer-dart
 
 platforms:

--- a/test/wait_task_test.dart
+++ b/test/wait_task_test.dart
@@ -375,6 +375,25 @@ void main() {
               .evaluate('x => x.textContent', args: [await waitForSelector]),
           equals('anything'));
     });
+    test('should disable timeout if Duration.zero is passed', () async {
+      var page = await browser.newPage();
+      await page.goto(server.emptyPage);
+      var frame = page.mainFrame;
+      var completed = false;
+      Object? error;
+      unawaited(frame
+          .waitForSelector('noexist', timeout: Duration.zero)
+          .whenComplete(() async {
+        completed = true;
+      }).catchError((e) {
+        error = e;
+      }));
+      await Future.delayed(const Duration(milliseconds: 500));
+      expect(completed, false);
+      await page.close();
+      expect(completed, true);
+      expect(error, isNotNull);
+    });
   });
 
   group('Frame.waitForXPath', () {


### PR DESCRIPTION
Fixes #210