### PR TITLE
Add parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.9.3
+- Add `captureBeyondViewport` parameter.
+
 ## 2.9.2
 - Add one more missing `AXPropertyName` entry.
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -1617,6 +1617,7 @@ Parameters:
 - [clip]: a [Rectangle] which specifies clipping region of the page.
 - [omitBackground]: Hides default white background and allows capturing
   screenshots with transparency. Defaults to `false`.
+- [captureBeyondViewport]: Capture the screenshot beyond the viewport. Defaults to `true`.
 
 Returns:
 [Future] which resolves to a list of bytes with captured screenshot.
@@ -1625,7 +1626,7 @@ Returns:
 https://crbug.com/741689 for discussion.
 
 ```dart
-page.screenshot({ScreenshotFormat? format, bool? fullPage, Rectangle? clip, int? quality, bool? omitBackground}) → Future<Uint8List> 
+page.screenshot({ScreenshotFormat? format, bool? fullPage, Rectangle? clip, int? quality, bool? omitBackground, bool? captureBeyondViewport = true}) → Future<Uint8List> 
 ```
 
 #### page.screenshotBase64(...)
@@ -1639,6 +1640,7 @@ Parameters:
 - [clip]: a [Rectangle] which specifies clipping region of the page.
 - [omitBackground]: Hides default white background and allows capturing
   screenshots with transparency. Defaults to `false`.
+- [captureBeyondViewport]: Capture the screenshot beyond the viewport. Defaults to `true`.
 
 Returns:
 [Future<String>] which resolves to the captured screenshot encoded in `base64`.
@@ -1647,7 +1649,7 @@ Returns:
 https://crbug.com/741689 for discussion.
 
 ```dart
-page.screenshotBase64({ScreenshotFormat? format, bool? fullPage, Rectangle? clip, int? quality, bool? omitBackground}) → Future<String> 
+page.screenshotBase64({ScreenshotFormat? format, bool? fullPage, Rectangle? clip, int? quality, bool? omitBackground, bool? captureBeyondViewport = true}) → Future<String> 
 ```
 
 #### page.select(String selector, List\<String> values)

--- a/doc/api.md
+++ b/doc/api.md
@@ -1617,7 +1617,8 @@ Parameters:
 - [clip]: a [Rectangle] which specifies clipping region of the page.
 - [omitBackground]: Hides default white background and allows capturing
   screenshots with transparency. Defaults to `false`.
-- [captureBeyondViewport]: Capture the screenshot beyond the viewport. Defaults to `true`.
+- [captureBeyondViewport]: Capture the screenshot beyond the viewport.
+  When false, cuts the screenshot by the viewport size. Defaults to `true`.
 
 Returns:
 [Future] which resolves to a list of bytes with captured screenshot.
@@ -1640,7 +1641,8 @@ Parameters:
 - [clip]: a [Rectangle] which specifies clipping region of the page.
 - [omitBackground]: Hides default white background and allows capturing
   screenshots with transparency. Defaults to `false`.
-- [captureBeyondViewport]: Capture the screenshot beyond the viewport. Defaults to `true`.
+- [captureBeyondViewport]: Capture the screenshot beyond the viewport.
+  When false, cuts the screenshot by the viewport size. Defaults to `true`.
 
 Returns:
 [Future<String>] which resolves to the captured screenshot encoded in `base64`.

--- a/lib/src/page/page.dart
+++ b/lib/src/page/page.dart
@@ -1427,6 +1427,7 @@ function deliverError(name, seq, message, stack) {
   /// - [clip]: a [Rectangle] which specifies clipping region of the page.
   /// - [omitBackground]: Hides default white background and allows capturing
   ///   screenshots with transparency. Defaults to `false`.
+  /// - [captureBeyondViewport]: Capture the screenshot beyond the viewport. Defaults to `true`.
   ///
   /// Returns:
   /// [Future] which resolves to a list of bytes with captured screenshot.
@@ -1438,13 +1439,15 @@ function deliverError(name, seq, message, stack) {
       bool? fullPage,
       Rectangle? clip,
       int? quality,
-      bool? omitBackground}) async {
+      bool? omitBackground,
+      bool? captureBeyondViewport = true}) async {
     return base64Decode(await screenshotBase64(
         format: format,
         fullPage: fullPage,
         clip: clip,
         quality: quality,
-        omitBackground: omitBackground));
+        omitBackground: omitBackground,
+        captureBeyondViewport: captureBeyondViewport));
   }
 
   /// Parameters:
@@ -1457,6 +1460,7 @@ function deliverError(name, seq, message, stack) {
   /// - [clip]: a [Rectangle] which specifies clipping region of the page.
   /// - [omitBackground]: Hides default white background and allows capturing
   ///   screenshots with transparency. Defaults to `false`.
+  /// - [captureBeyondViewport]: Capture the screenshot beyond the viewport. Defaults to `true`.
   ///
   /// Returns:
   /// [Future<String>] which resolves to the captured screenshot encoded in `base64`.
@@ -1468,7 +1472,8 @@ function deliverError(name, seq, message, stack) {
       bool? fullPage,
       Rectangle? clip,
       int? quality,
-      bool? omitBackground}) {
+      bool? omitBackground,
+      bool? captureBeyondViewport = true}) {
     final localFormat = format ?? ScreenshotFormat.png;
     final localFullPage = fullPage ?? false;
     omitBackground ??= false;
@@ -1511,7 +1516,7 @@ function deliverError(name, seq, message, stack) {
           format: localFormat.name,
           quality: quality,
           clip: roundedClip,
-          captureBeyondViewport: false);
+          captureBeyondViewport: captureBeyondViewport);
       if (shouldSetDefaultBackground) {
         await devTools.emulation.setDefaultBackgroundColorOverride();
       }

--- a/lib/src/page/page.dart
+++ b/lib/src/page/page.dart
@@ -1511,7 +1511,7 @@ function deliverError(name, seq, message, stack) {
           format: localFormat.name,
           quality: quality,
           clip: roundedClip,
-          captureBeyondViewport: true);
+          captureBeyondViewport: false);
       if (shouldSetDefaultBackground) {
         await devTools.emulation.setDefaultBackgroundColorOverride();
       }

--- a/lib/src/page/page.dart
+++ b/lib/src/page/page.dart
@@ -1427,7 +1427,8 @@ function deliverError(name, seq, message, stack) {
   /// - [clip]: a [Rectangle] which specifies clipping region of the page.
   /// - [omitBackground]: Hides default white background and allows capturing
   ///   screenshots with transparency. Defaults to `false`.
-  /// - [captureBeyondViewport]: Capture the screenshot beyond the viewport. Defaults to `true`.
+  /// - [captureBeyondViewport]: Capture the screenshot beyond the viewport.
+  ///   When false, cuts the screenshot by the viewport size. Defaults to `true`.
   ///
   /// Returns:
   /// [Future] which resolves to a list of bytes with captured screenshot.
@@ -1460,7 +1461,8 @@ function deliverError(name, seq, message, stack) {
   /// - [clip]: a [Rectangle] which specifies clipping region of the page.
   /// - [omitBackground]: Hides default white background and allows capturing
   ///   screenshots with transparency. Defaults to `false`.
-  /// - [captureBeyondViewport]: Capture the screenshot beyond the viewport. Defaults to `true`.
+  /// - [captureBeyondViewport]: Capture the screenshot beyond the viewport.
+  ///   When false, cuts the screenshot by the viewport size. Defaults to `true`.
   ///
   /// Returns:
   /// [Future<String>] which resolves to the captured screenshot encoded in `base64`.


### PR DESCRIPTION
@xvrh while upgrading dependencies in a few repos we maintain we noticed an issue where the page would rerender when taking a screenshot which resulted in some unexpected differences. We can work around the issue by setting `captureBeyondViewport` to false. 

Looking at the the TS version of puppeteer it appears this parameter is already [exposed](https://github.com/puppeteer/puppeteer/blob/06e816bbfa7b9ca84284929f654de7288c51169d/packages/puppeteer-core/src/api/Page.ts#L183-L187) to the user. Making the same change here and would appreciate releasing as `2.9.3`. I will  also make a follow-up change off of master.