### PR TITLE
Bad state: Future already completed

### DIFF
--- a/lib/src/page/dom_world.dart
+++ b/lib/src/page/dom_world.dart
@@ -475,7 +475,9 @@ class WaitTask {
         return;
       }
 
-      _completer.complete(success);
+      if (!_completer.isCompleted) {
+        _completer.complete(success);
+      }
     } on Exception catch (error) {
       // When the page is navigated, the promise is rejected.
       // We will try again in the new execution context.


### PR DESCRIPTION
Suggested fix for an exception we've intermittently been experiencing on puppeteer-dart `v2.24.0`

If this fix seems appropriate, can it also be backported since we're still on v2?

```
Bad state: Future already completed
dart:async                                                                                 _AsyncCompleter.complete
package:puppeteer/src/page/dom_world.dart 478:18                                           WaitTask.rerun
===== asynchronous gap ===========================
dart:async                                                                                 _CustomZone.registerUnaryCallback
package:puppeteer/src/page/dom_world.dart 461:21                                           WaitTask.rerun
package:puppeteer/src/page/dom_world.dart 439:5                                            new WaitTask
package:puppeteer/src/page/dom_world.dart 388:20                                           DomWorld._waitForSelectorOrXPath
package:puppeteer/src/page/dom_world.dart 328:12                                           DomWorld.waitForXPath
package:puppeteer/src/page/frame_manager.dart 867:40                                       Frame.waitForXPath
package:puppeteer/src/page/page.dart 1912:22                                               Page.waitForXPath
```