### PR TITLE
Fix navigation error

### DIFF
--- a/lib/src/page/dom_world.dart
+++ b/lib/src/page/dom_world.dart
@@ -31,7 +31,12 @@ class DomWorld {
       }
     } else {
       if (_contextCompleter != null && !_contextCompleter!.isCompleted) {
-        _contextCompleter!.completeError('Context is disposed');
+        try {
+          _contextCompleter!.complete(_contextCompleter!.future);
+          _contextCompleter = null;
+        } catch (e) {
+          _contextCompleter!.completeError('Context is disposed');
+        }
       }
       _contextCompleter = Completer<ExecutionContext>();
     }

--- a/lib/src/page/dom_world.dart
+++ b/lib/src/page/dom_world.dart
@@ -16,24 +16,17 @@ class DomWorld {
   bool _detached = false;
 
   DomWorld(this.frameManager, this.frame) {
-    setContext(null);
+    _contextCompleter = Completer<ExecutionContext>();
   }
 
-  void setContext(ExecutionContext? context) {
-    if (context != null) {
-      _documentFuture = null;
-      if (!_contextCompleter!.isCompleted) {
-        _contextCompleter!.complete(context);
+  void setContext(ExecutionContext context) {
+    _documentFuture = null;
+    if (!_contextCompleter!.isCompleted) {
+      _contextCompleter!.complete(context);
 
-        for (var waitTask in _waitTasks) {
-          waitTask.rerun();
-        }
+      for (var waitTask in _waitTasks) {
+        waitTask.rerun();
       }
-    } else {
-      if (_contextCompleter != null && !_contextCompleter!.isCompleted) {
-        _contextCompleter!.completeError('Context is disposed');
-      }
-      _contextCompleter = Completer<ExecutionContext>();
     }
   }
 

--- a/lib/src/page/dom_world.dart
+++ b/lib/src/page/dom_world.dart
@@ -31,15 +31,20 @@ class DomWorld {
       }
     } else {
       if (_contextCompleter != null && !_contextCompleter!.isCompleted) {
-        try {
-          _contextCompleter!.complete(_contextCompleter!.future);
-          _contextCompleter = null;
-        } catch (e) {
-          _contextCompleter!.completeError('Context is disposed');
-        }
+        _contextCompleter!.completeError('Context is disposed');
       }
       _contextCompleter = Completer<ExecutionContext>();
     }
+  }
+
+  void clearContext() {
+    _contextCompleter = null;
+    _contextCompleter = Completer<ExecutionContext>();
+  }
+
+  void destroyContext() {
+    _contextCompleter!.completeError('Context was disposed');
+    _contextCompleter = Completer<ExecutionContext>();
   }
 
   bool get hasContext =>

--- a/lib/src/page/dom_world.dart
+++ b/lib/src/page/dom_world.dart
@@ -38,12 +38,13 @@ class DomWorld {
   }
 
   void clearContext() {
-    _contextCompleter = null;
     _contextCompleter = Completer<ExecutionContext>();
   }
 
   void destroyContext() {
-    _contextCompleter!.completeError('Context was disposed');
+    if (_contextCompleter != null && !_contextCompleter!.isCompleted) {
+      _contextCompleter!.completeError('Context is disposed');
+    }
     _contextCompleter = Completer<ExecutionContext>();
   }
 

--- a/lib/src/page/dom_world.dart
+++ b/lib/src/page/dom_world.dart
@@ -16,7 +16,7 @@ class DomWorld {
   bool _detached = false;
 
   DomWorld(this.frameManager, this.frame) {
-    _contextCompleter = Completer<ExecutionContext>();
+    clearContext();
   }
 
   void setContext(ExecutionContext context) {

--- a/lib/src/page/frame_manager.dart
+++ b/lib/src/page/frame_manager.dart
@@ -297,13 +297,13 @@ class FrameManager {
     }
     _contextIdToContext.remove(executionContextId);
     if (context.world != null) {
-      context.world!.setContext(null);
+      context.world!.destroyContext();
     }
   }
 
   void _onExecutionContextsCleared(_) {
     for (var context in _contextIdToContext.values) {
-      if (context.world != null) context.world!.setContext(null);
+      if (context.world != null) context.world!.clearContext();
     }
     _contextIdToContext.clear();
   }

--- a/test/browser_context_test.dart
+++ b/test/browser_context_test.dart
@@ -112,6 +112,15 @@ void main() {
           throwsA(TypeMatcher<TimeoutException>()));
       await context.close();
     });
+    test('Navigation does not result in `Context is disposed` error', () async {
+      var context = await browser.createIncognitoBrowserContext();
+      var page = await context.newPage();
+      await page.devTools.network.emulateNetworkConditions(false, 1000, 1000000, 1000000);
+      await page.goto('https://www.naver.com');
+      await page.goto('https://www.naver.com');
+      await context.close();
+      expect(browser.browserContexts, hasLength(1));
+    });
     test('should isolate localStorage and cookies', () async {
       // Create two incognito contexts.
       var context1 = await browser.createIncognitoBrowserContext();

--- a/test/browser_context_test.dart
+++ b/test/browser_context_test.dart
@@ -116,7 +116,8 @@ void main() {
       final startingContext = browser.browserContexts.length;
       var context = await browser.createIncognitoBrowserContext();
       var page = await context.newPage();
-      await page.devTools.network.emulateNetworkConditions(false, 1000, 1000000, 1000000);
+      await page.devTools.network
+          .emulateNetworkConditions(false, 1000, 1000000, 1000000);
       await page.goto('https://www.naver.com');
       await page.goto('https://www.naver.com');
       await context.close();

--- a/test/browser_context_test.dart
+++ b/test/browser_context_test.dart
@@ -112,14 +112,15 @@ void main() {
           throwsA(TypeMatcher<TimeoutException>()));
       await context.close();
     });
-    test('Navigation does not result in `Context is disposed` error', () async {
+    test('should complete navigation without context disposal error', () async {
+      final startingContext = browser.browserContexts.length;
       var context = await browser.createIncognitoBrowserContext();
       var page = await context.newPage();
       await page.devTools.network.emulateNetworkConditions(false, 1000, 1000000, 1000000);
       await page.goto('https://www.naver.com');
       await page.goto('https://www.naver.com');
       await context.close();
-      expect(browser.browserContexts, hasLength(1));
+      expect(browser.browserContexts, hasLength(startingContext));
     });
     test('should isolate localStorage and cookies', () async {
       // Create two incognito contexts.


### PR DESCRIPTION
@xvrh We've started to see an issue similar to https://github.com/xvrh/puppeteer-dart/issues/237 in our tests. I was able to create a test that [fails](https://github.com/xvrh/puppeteer-dart/actions/runs/9097232736/job/25004572232) consistently without any changes committed.

Then committed some changes that work around the issue but I'm lacking the context that you likely have over the entirety of this project to say if those changes would cause issues elsewhere. 

I operated under the assumption that in the `_onExecutionContextsCleared` scenario we should go quietly into the night instead of erroring and `_onExecutionContextsDestroyed` we should error. But perhaps that was a poor assumption. Looking for any guidance/insight you might have on how to solve this issue.