### PR TITLE
Change close code for websocket in web to 1000

### DIFF
--- a/lib/src/websocket_html.dart
+++ b/lib/src/websocket_html.dart
@@ -29,7 +29,7 @@ class _Websocket implements WebSocket {
   @override
   Future<void> close(String reason) async {
     _closeReason = reason;
-    return _socket.close(1, reason);
+    return _socket.close(1000, reason);
   }
 
   @override


### PR DESCRIPTION
As observed in web, real use case, when calling browser.disconnect:

main.dart.js:8362 Uncaught Error: InvalidAccessError: Failed to execute 'close' on 'WebSocket': The close code must be either 1000, or between 3000 and 4999. 1 is neither.
    at main.dart.js:209306:56
    at _wrapJsFunctionForAsync_closure.$protected (main.dart.js:11262:15)
    at _wrapJsFunctionForAsync_closure.call$2 (main.dart.js:80376:12)
    at Object._asyncStartSync (main.dart.js:11226:20)
    at _Websocket.close$body$_Websocket (main.dart.js:209315:16)
    at _Websocket.close$1 (main.dart.js:209292:19)
    at main.dart.js:205193:59
    at _wrapJsFunctionForAsync_closure.$protected (main.dart.js:11262:15)
    at _wrapJsFunctionForAsync_closure.call$2 (main.dart.js:80376:12)
    at Object._asyncStartSync (main.dart.js:11226:20)