### PR TITLE
Coordinate browser downloads across processes and isolates

### DIFF
--- a/lib/src/downloader.dart
+++ b/lib/src/downloader.dart
@@ -28,6 +28,11 @@ class DownloadedBrowserInfo {
 ///     print('downloaded $received of $total bytes');
 ///   });
 /// ```
+///
+/// Concurrent calls (within the same isolate, across isolates in the same VM,
+/// and across separate processes) are coordinated so that only one actually
+/// downloads and unzips Chrome. Other callers wait for the in-flight download
+/// to finish, then return a path to the same shared installation.
 Future<DownloadedBrowserInfo> downloadChrome({
   String? version,
   String? cachePath,
@@ -38,42 +43,214 @@ Future<DownloadedBrowserInfo> downloadChrome({
   cachePath ??= '.local-chrome';
   platform ??= BrowserPlatform.current;
 
-  var revisionDirectory = Directory(p.join(cachePath, version));
-  if (!revisionDirectory.existsSync()) {
-    revisionDirectory.createSync(recursive: true);
-  }
-
-  var exePath = p.join(revisionDirectory.path, getExecutablePath(platform));
-
-  var executableFile = File(exePath);
-
-  if (!executableFile.existsSync()) {
-    var url = _downloadUrl(platform, version);
-    var zipPath = p.join(revisionDirectory.path, p.url.basename(url));
-    await _downloadFile(url, zipPath, onDownloadProgress);
-    _unzip(zipPath, revisionDirectory.path);
-    File(zipPath).deleteSync();
-
-    if (!executableFile.existsSync()) {
-      throw Exception("$exePath doesn't exist");
-    }
-
-    if (!Platform.isWindows) {
-      await Process.run('chmod', ['+x', executableFile.absolute.path]);
-    }
-
-    if (Platform.isMacOS) {
-      final chromeAppPath = executableFile.absolute.parent.parent.parent.path;
-
-      await Process.run('xattr', ['-d', 'com.apple.quarantine', chromeAppPath]);
-    }
-  }
-
-  return DownloadedBrowserInfo(
-    folderPath: revisionDirectory.path,
-    executablePath: executableFile.path,
+  final platformLocal = platform;
+  return ensureBrowserDownloaded(
+    cachePath: cachePath,
     version: version,
+    executableRelPath: getExecutablePath(platformLocal),
+    download: (partialDir) async {
+      final url = _downloadUrl(platformLocal, version!);
+      final zipPath = p.join(partialDir, p.url.basename(url));
+      await _downloadFile(url, zipPath, onDownloadProgress);
+      _unzip(zipPath, partialDir);
+      File(zipPath).deleteSync();
+
+      final exePath = p.join(partialDir, getExecutablePath(platformLocal));
+      final executableFile = File(exePath);
+      if (!executableFile.existsSync()) {
+        throw Exception("$exePath doesn't exist");
+      }
+
+      if (!Platform.isWindows) {
+        await Process.run('chmod', ['+x', executableFile.absolute.path]);
+      }
+      if (Platform.isMacOS) {
+        final chromeAppPath = executableFile.absolute.parent.parent.parent.path;
+        await Process.run('xattr', ['-d', 'com.apple.quarantine', chromeAppPath]);
+      }
+    },
   );
+}
+
+/// Coordinates a browser download into [cachePath]/[version], ensuring at most
+/// one caller (across isolates and processes) actually runs [download].
+///
+/// Coordination uses the filesystem so it works across processes: the owning
+/// caller creates a `<version>.downloading` directory (atomic mkdir), runs
+/// [download] inside it, then atomically renames it to `<version>`. Other
+/// concurrent callers detect the existing directory and poll until the
+/// executable appears (or until the dir is cleaned up after a failure).
+///
+/// [staleThreshold] guards against orphaned `<version>.downloading` directories
+/// left behind by a crashed prior caller; if the directory's mtime is older
+/// than this, it is removed and ownership is retried.
+///
+/// [waitTimeout] caps the total time a waiter will block.
+Future<DownloadedBrowserInfo> ensureBrowserDownloaded({
+  required String cachePath,
+  required String version,
+  required String executableRelPath,
+  required Future<void> Function(String partialDir) download,
+  Duration waitTimeout = const Duration(minutes: 15),
+  Duration staleThreshold = const Duration(minutes: 15),
+  Duration pollInterval = const Duration(milliseconds: 100),
+}) {
+  final key = '$cachePath|$version|$executableRelPath';
+  final existing = _inFlightDownloads[key];
+  if (existing != null) return existing;
+  final future = _runEnsureDownloaded(
+    cachePath: cachePath,
+    version: version,
+    executableRelPath: executableRelPath,
+    download: download,
+    waitTimeout: waitTimeout,
+    staleThreshold: staleThreshold,
+    pollInterval: pollInterval,
+  );
+  _inFlightDownloads[key] = future;
+  // Use whenComplete to clear the cache entry whether the download succeeded
+  // or failed. The Future returned by whenComplete is intentionally ignored
+  // to avoid an "unhandled error" warning if the download throws — error
+  // handling is the caller's responsibility on `future` itself.
+  future.whenComplete(() {
+    if (identical(_inFlightDownloads[key], future)) {
+      _inFlightDownloads.remove(key);
+    }
+  }).ignore();
+  return future;
+}
+
+final Map<String, Future<DownloadedBrowserInfo>> _inFlightDownloads = {};
+
+Future<DownloadedBrowserInfo> _runEnsureDownloaded({
+  required String cachePath,
+  required String version,
+  required String executableRelPath,
+  required Future<void> Function(String partialDir) download,
+  required Duration waitTimeout,
+  required Duration staleThreshold,
+  required Duration pollInterval,
+}) async {
+  final versionDir = Directory(p.join(cachePath, version));
+  final exeFile = File(p.join(versionDir.path, executableRelPath));
+  final downloadingDir = Directory(p.join(cachePath, '$version.downloading'));
+  // Lock file is the atomic mutex. File.createSync(exclusive: true) maps to
+  // O_CREAT|O_EXCL on POSIX and CREATE_NEW on Windows, both atomic across
+  // processes and isolates.
+  final lockFile = File(p.join(cachePath, '$version.downloading.lock'));
+
+  DownloadedBrowserInfo result() => DownloadedBrowserInfo(
+        executablePath: exeFile.path,
+        folderPath: versionDir.path,
+        version: version,
+      );
+
+  if (exeFile.existsSync()) return result();
+
+  Directory(cachePath).createSync(recursive: true);
+
+  final deadline = DateTime.now().add(waitTimeout);
+
+  while (true) {
+    if (exeFile.existsSync()) return result();
+    if (DateTime.now().isAfter(deadline)) {
+      throw TimeoutException(
+        'Timed out waiting for browser download to ${versionDir.path}. '
+        'If a previous download crashed, delete ${lockFile.path} to retry.',
+      );
+    }
+
+    var weOwn = false;
+    try {
+      lockFile.createSync(exclusive: true);
+      weOwn = true;
+    } on PathExistsException {
+      // Another caller holds the lock — fall through to the waiter path.
+    }
+
+    if (weOwn) {
+      try {
+        // Clean any leftover state from a prior failed attempt.
+        _safeDelete(downloadingDir);
+        if (versionDir.existsSync() && !exeFile.existsSync()) {
+          // <version>/ exists without exe — anomalous (rename is atomic).
+          // Clean it up so our atomic rename below can succeed.
+          _safeDelete(versionDir);
+        }
+        downloadingDir.createSync(recursive: true);
+
+        await download(downloadingDir.path);
+        final partialExe = File(p.join(downloadingDir.path, executableRelPath));
+        if (!partialExe.existsSync()) {
+          throw Exception(
+            'Download callback completed but executable was not produced at '
+            "'$executableRelPath' inside '${downloadingDir.path}'.",
+          );
+        }
+
+        try {
+          await downloadingDir.rename(versionDir.path);
+        } on FileSystemException {
+          if (versionDir.existsSync() && exeFile.existsSync()) {
+            _safeDelete(downloadingDir);
+          } else {
+            rethrow;
+          }
+        }
+        return result();
+      } finally {
+        _safeDelete(downloadingDir); // no-op if rename succeeded
+        try {
+          if (lockFile.existsSync()) lockFile.deleteSync();
+        } on FileSystemException {
+          // ignore
+        }
+      }
+    }
+
+    // Waiter path: poll until exe appears, lock disappears, or it goes stale.
+    while (true) {
+      if (DateTime.now().isAfter(deadline)) {
+        throw TimeoutException(
+          'Timed out waiting for another process to finish downloading '
+          'browser to ${versionDir.path}. If a previous download crashed, '
+          'delete ${lockFile.path} to retry.',
+        );
+      }
+      await Future<void>.delayed(pollInterval);
+      if (exeFile.existsSync()) return result();
+      if (!lockFile.existsSync()) break;
+      if (_isStaleFile(lockFile, staleThreshold)) {
+        try {
+          lockFile.deleteSync();
+        } on FileSystemException {
+          // Another caller already cleaned it up.
+        }
+        break;
+      }
+    }
+  }
+}
+
+bool _isStaleFile(File f, Duration threshold) {
+  try {
+    final mtime = f.statSync().modified;
+    return DateTime.now().difference(mtime) > threshold;
+  } on FileSystemException {
+    return false;
+  }
+}
+
+void _safeDelete(FileSystemEntity entity) {
+  try {
+    if (entity is Directory) {
+      if (entity.existsSync()) entity.deleteSync(recursive: true);
+    } else if (entity is File) {
+      if (entity.existsSync()) entity.deleteSync();
+    }
+  } on FileSystemException {
+    // Ignore: another caller likely cleaned it up.
+  }
 }
 
 Future<void> _downloadFile(

--- a/test/downloader_concurrent_test.dart
+++ b/test/downloader_concurrent_test.dart
@@ -1,0 +1,221 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'package:path/path.dart' as p;
+import 'package:puppeteer/src/downloader.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ensureBrowserDownloaded', () {
+    late Directory tmp;
+
+    setUp(() {
+      tmp = Directory.systemTemp.createTempSync('puppeteer-conc-');
+    });
+
+    tearDown(() {
+      if (tmp.existsSync()) {
+        tmp.deleteSync(recursive: true);
+      }
+    });
+
+    test('fast path: returns immediately when executable exists', () async {
+      final versionDir = Directory(p.join(tmp.path, '1.0.0', 'chrome'));
+      versionDir.createSync(recursive: true);
+      File(p.join(versionDir.path, 'exe')).writeAsStringSync('binary');
+
+      var downloadCalled = false;
+      final info = await ensureBrowserDownloaded(
+        cachePath: tmp.path,
+        version: '1.0.0',
+        executableRelPath: p.join('chrome', 'exe'),
+        download: (_) async {
+          downloadCalled = true;
+        },
+      );
+
+      expect(downloadCalled, isFalse);
+      expect(File(info.executablePath).existsSync(), isTrue);
+      expect(info.version, '1.0.0');
+    });
+
+    test('concurrent calls in same isolate share a single download', () async {
+      var downloadCount = 0;
+      Future<DownloadedBrowserInfo> call() => ensureBrowserDownloaded(
+            cachePath: tmp.path,
+            version: '1.2.3',
+            executableRelPath: p.join('chrome', 'exe'),
+            download: (partialDir) async {
+              downloadCount++;
+              await Future<void>.delayed(const Duration(milliseconds: 100));
+              Directory(p.join(partialDir, 'chrome')).createSync(recursive: true);
+              File(p.join(partialDir, 'chrome', 'exe')).writeAsStringSync('binary');
+            },
+          );
+
+      final results = await Future.wait([call(), call(), call(), call(), call()]);
+
+      expect(downloadCount, 1, reason: 'Future cache should dedupe concurrent calls');
+      for (final r in results) {
+        expect(File(r.executablePath).existsSync(), isTrue);
+        expect(r.executablePath, results.first.executablePath);
+      }
+    });
+
+    test('cross-process concurrent download deduplicates', () async {
+      final logDir = Directory(p.join(tmp.path, '_log'))..createSync();
+      final barrier = File(p.join(tmp.path, '_go'));
+      final workerScript = p.join(
+        Directory.current.path,
+        'test',
+        'utils',
+        'concurrent_download_worker.dart',
+      );
+
+      const workerCount = 4;
+      final processes = await Future.wait(List.generate(
+        workerCount,
+        (i) => Process.start(
+          Platform.executable,
+          [workerScript, tmp.path, logDir.path, i.toString(), barrier.path],
+        ),
+      ));
+
+      // Wait until every worker reports "ready" before flipping the barrier,
+      // so they all hit ensureBrowserDownloaded near-simultaneously.
+      final outputs = List.generate(workerCount, (_) => StringBuffer());
+      final readyFutures = <Future<void>>[];
+      for (var i = 0; i < workerCount; i++) {
+        final lines = processes[i].stdout
+            .transform(const SystemEncoding().decoder)
+            .transform(const LineSplitter())
+            .asBroadcastStream();
+        final readyCompleter = Completer<void>();
+        lines.listen((line) {
+          if (line == 'ready' && !readyCompleter.isCompleted) {
+            readyCompleter.complete();
+          } else {
+            outputs[i].writeln(line);
+          }
+        }, onDone: () {
+          if (!readyCompleter.isCompleted) {
+            readyCompleter.complete();
+          }
+        });
+        readyFutures.add(readyCompleter.future);
+      }
+      await Future.wait(readyFutures);
+
+      barrier.writeAsStringSync('go');
+
+      final exitCodes = await Future.wait(processes.map((p) => p.exitCode));
+      for (var i = 0; i < workerCount; i++) {
+        expect(exitCodes[i], 0, reason: 'worker $i exited non-zero');
+      }
+
+      final downloadCount = logDir.listSync().length;
+      expect(downloadCount, 1,
+          reason: 'Exactly one process should do the actual download');
+
+      final paths = outputs.map((b) => b.toString().trim()).toSet();
+      expect(paths.length, 1,
+          reason: 'All workers should report the same path; got $paths');
+      expect(File(paths.single).existsSync(), isTrue);
+    }, timeout: const Timeout(Duration(seconds: 60)));
+
+    test('atomic rename: <version> never visible until download completes',
+        () async {
+      final versionPath = p.join(tmp.path, '1.0.0');
+      var sawIncomplete = false;
+      final completer = Completer<void>();
+
+      final downloadFuture = ensureBrowserDownloaded(
+        cachePath: tmp.path,
+        version: '1.0.0',
+        executableRelPath: p.join('chrome', 'exe'),
+        download: (partialDir) async {
+          // Inside the partial dir, create the executable then signal.
+          Directory(p.join(partialDir, 'chrome')).createSync(recursive: true);
+          File(p.join(partialDir, 'chrome', 'exe')).writeAsStringSync('binary');
+          // While this download "runs", the version directory must not exist yet.
+          if (Directory(versionPath).existsSync()) {
+            sawIncomplete = true;
+          }
+          completer.complete();
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+        },
+      );
+
+      await completer.future;
+      // At this point the download callback is mid-flight (not yet renamed).
+      expect(Directory(versionPath).existsSync(), isFalse,
+          reason: 'version dir must not exist until download completes');
+
+      await downloadFuture;
+      expect(Directory(versionPath).existsSync(), isTrue);
+      expect(sawIncomplete, isFalse);
+    });
+
+    test('stale lock file is recovered after staleThreshold', () async {
+      File(p.join(tmp.path, '1.0.0.downloading.lock')).createSync();
+      // Wait so the lock file's mtime is older than the staleThreshold below.
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      var downloadRan = false;
+      final info = await ensureBrowserDownloaded(
+        cachePath: tmp.path,
+        version: '1.0.0',
+        executableRelPath: p.join('chrome', 'exe'),
+        download: (partialDir) async {
+          downloadRan = true;
+          Directory(p.join(partialDir, 'chrome')).createSync(recursive: true);
+          File(p.join(partialDir, 'chrome', 'exe')).writeAsStringSync('binary');
+        },
+        staleThreshold: const Duration(milliseconds: 50),
+        waitTimeout: const Duration(seconds: 5),
+      );
+
+      expect(downloadRan, isTrue);
+      expect(File(info.executablePath).existsSync(), isTrue);
+    });
+
+    test('owner failure: waiter retries when .downloading disappears without exe',
+        () async {
+      // Simulate: one caller fails (callback throws), another caller succeeds.
+      final firstFailed = Completer<void>();
+
+      final failingCall = ensureBrowserDownloaded(
+        cachePath: tmp.path,
+        version: '1.0.0',
+        executableRelPath: p.join('chrome', 'exe'),
+        download: (_) async {
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+          firstFailed.complete();
+          throw StateError('simulated owner failure');
+        },
+      );
+
+      // Wait until the failing call is in progress, then start a second call.
+      // Since both are in the same isolate, the Future cache will return the
+      // same Future to both — so we need to start the second call AFTER the
+      // first one's Future has been removed from the cache (i.e., after it
+      // throws). Awaiting the failing call's error first achieves that.
+      await expectLater(failingCall, throwsStateError);
+
+      // Now the .downloading dir should be cleaned up by the owner before it
+      // released. A subsequent call should succeed.
+      final info = await ensureBrowserDownloaded(
+        cachePath: tmp.path,
+        version: '1.0.0',
+        executableRelPath: p.join('chrome', 'exe'),
+        download: (partialDir) async {
+          Directory(p.join(partialDir, 'chrome')).createSync(recursive: true);
+          File(p.join(partialDir, 'chrome', 'exe')).writeAsStringSync('binary');
+        },
+      );
+
+      expect(File(info.executablePath).existsSync(), isTrue);
+      expect(firstFailed.isCompleted, isTrue);
+    });
+  });
+}

--- a/test/utils/concurrent_download_worker.dart
+++ b/test/utils/concurrent_download_worker.dart
@@ -1,0 +1,42 @@
+import 'dart:io';
+import 'package:path/path.dart' as p;
+import 'package:puppeteer/src/downloader.dart';
+
+/// Worker script for the cross-process concurrency test.
+///
+/// Args: `<cachePath> <logDir> <workerId> <barrierFile>`
+///
+/// 1. Prints "ready" and waits for `barrierFile` to appear (so the parent test
+///    can release all workers simultaneously and they actually race).
+/// 2. Calls [ensureBrowserDownloaded] with a fake download callback that
+///    records itself by creating a file in `logDir`. Counting files in
+///    `logDir` tells the parent how many workers actually did the download.
+Future<void> main(List<String> args) async {
+  final cachePath = args[0];
+  final logDir = args[1];
+  final workerId = args[2];
+  final barrierFile = File(args[3]);
+
+  stdout.writeln('ready');
+  while (!barrierFile.existsSync()) {
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+
+  final info = await ensureBrowserDownloaded(
+    cachePath: cachePath,
+    version: '1.2.3',
+    executableRelPath: p.join('chrome', 'exe'),
+    download: (partialDir) async {
+      File(
+        p.join(logDir, 'download-$workerId-${DateTime.now().microsecondsSinceEpoch}'),
+      ).writeAsStringSync('downloaded by $workerId');
+      // Long enough that any concurrent worker reaching createSync after us
+      // will hit EEXIST and become a waiter.
+      await Future<void>.delayed(const Duration(seconds: 2));
+      Directory(p.join(partialDir, 'chrome')).createSync(recursive: true);
+      File(p.join(partialDir, 'chrome', 'exe')).writeAsStringSync('fake binary');
+    },
+  );
+
+  stdout.writeln(info.executablePath);
+}


### PR DESCRIPTION
Refactors the browser downloader to safely handle concurrent download requests from multiple processes or isolates.

It uses a filesystem-based locking mechanism and atomic directory renames to:
- Ensure only one download of a specific browser version occurs at a time.
- Prevent partially downloaded browsers from being used or left in a corrupt state.
- Recover from stale download states left by crashed processes.

Adds comprehensive tests for concurrency, atomic updates, and failure recovery.