### PR TITLE
Move default browser cache to .dart_tool or OS user cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 3.23.0
+- Update to Chrome 148.0.7778.97.
+- `downloadChrome` is now safe to call concurrently across isolates and
+  processes: only one caller actually downloads Chrome; others wait and
+  share the result. Useful when multiple `dart test` isolates each call
+  `puppeteer.launch()` against an empty cache.
+- Default `cachePath` moved from `.local-chrome/` to
+  `.dart_tool/puppeteer/local-chrome/` (under the current Dart project or
+  workspace root), per Dart's project-specific tool caching convention. For
+  AOT-compiled binaries with no package config, falls back to an OS user
+  cache dir (`~/Library/Caches/puppeteer`, `~/.cache/puppeteer`, or
+  `%LOCALAPPDATA%\puppeteer`). Existing `.local-chrome/` directories on disk
+  can be deleted manually.
+
 ## 3.22.0
 - Update to Chrome 147.0.7727.56.
 

--- a/example/download_chrome.dart
+++ b/example/download_chrome.dart
@@ -2,7 +2,9 @@ import 'package:puppeteer/puppeteer.dart';
 
 void main() async {
   var chromePath = await downloadChrome(
-    // Specify the custom location (by default it .local-chrome)
+    // Specify a custom cache location. When omitted, Chrome is cached in
+    // `.dart_tool/puppeteer/local-chrome/` under the current Dart project
+    // (or workspace root, if any).
     cachePath: null,
   );
   print(chromePath.executablePath);

--- a/lib/src/downloader.dart
+++ b/lib/src/downloader.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:isolate';
 import 'package:archive/archive.dart';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
@@ -18,8 +19,57 @@ class DownloadedBrowserInfo {
   });
 }
 
+/// Returns the default cache directory used by [downloadChrome] when no
+/// `cachePath` is provided.
 ///
-/// Downloads the chrome revision specified by [revision] to the [cachePath] directory.
+/// When a Dart package config is available at runtime (the normal case for
+/// `dart test`, `flutter test`, `dart run`, `flutter run`, …), this resolves
+/// to `<workspace-root>/.dart_tool/puppeteer/local-chrome` per Dart's
+/// project-specific tool caching convention. In a workspace this is the
+/// workspace root, so all member packages share a single Chrome download.
+///
+/// When no package config is available — which is the case for AOT-compiled
+/// executables — this falls back to an OS-appropriate user cache directory.
+String defaultBrowserCachePath() {
+  final config = Isolate.packageConfigSync;
+  if (config != null) {
+    return config.resolve('puppeteer/local-chrome/').toFilePath();
+  }
+  return _osUserCacheDir();
+}
+
+String _osUserCacheDir() {
+  final env = Platform.environment;
+  if (Platform.isMacOS) {
+    final home = env['HOME'];
+    if (home != null && home.isNotEmpty) {
+      return p.join(home, 'Library', 'Caches', 'puppeteer', 'local-chrome');
+    }
+  } else if (Platform.isWindows) {
+    final localAppData = env['LOCALAPPDATA'];
+    if (localAppData != null && localAppData.isNotEmpty) {
+      return p.join(localAppData, 'puppeteer', 'local-chrome');
+    }
+  } else {
+    // Linux / other POSIX.
+    final xdgCache = env['XDG_CACHE_HOME'];
+    if (xdgCache != null && xdgCache.isNotEmpty) {
+      return p.join(xdgCache, 'puppeteer', 'local-chrome');
+    }
+    final home = env['HOME'];
+    if (home != null && home.isNotEmpty) {
+      return p.join(home, '.cache', 'puppeteer', 'local-chrome');
+    }
+  }
+  // Last resort: temp dir. Not ideal (potentially wiped on reboot) but better
+  // than failing.
+  return p.join(Directory.systemTemp.path, 'puppeteer', 'local-chrome');
+}
+
+///
+/// Downloads the chrome revision specified by [version] to the [cachePath]
+/// directory.
+///
 /// ```dart
 /// await downloadChrome(
 ///   version: '112.0.5615.121',
@@ -28,6 +78,13 @@ class DownloadedBrowserInfo {
 ///     print('downloaded $received of $total bytes');
 ///   });
 /// ```
+///
+/// When [cachePath] is omitted, the default location is
+/// `.dart_tool/puppeteer/local-chrome/` under the current Dart project (or
+/// workspace root). For executables compiled to AOT — where the package
+/// config isn't available at runtime — the default falls back to an OS
+/// user cache directory (e.g. `~/Library/Caches/puppeteer` on macOS,
+/// `~/.cache/puppeteer` on Linux, `%LOCALAPPDATA%\puppeteer` on Windows).
 ///
 /// Concurrent calls (within the same isolate, across isolates in the same VM,
 /// and across separate processes) are coordinated so that only one actually
@@ -40,7 +97,7 @@ Future<DownloadedBrowserInfo> downloadChrome({
   BrowserPlatform? platform,
 }) async {
   version ??= _lastVersion;
-  cachePath ??= '.local-chrome';
+  cachePath ??= defaultBrowserCachePath();
   platform ??= BrowserPlatform.current;
 
   final platformLocal = platform;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: puppeteer
 description: A high-level API to control headless Chrome over the DevTools Protocol. This is a port of Puppeteer in Dart.
-version: 3.22.0
+version: 3.23.0
 homepage: https://github.com/xvrh/puppeteer-dart
 
 funding:

--- a/test/downloader_default_path_test.dart
+++ b/test/downloader_default_path_test.dart
@@ -1,0 +1,36 @@
+import 'dart:io';
+import 'package:path/path.dart' as p;
+import 'package:puppeteer/src/downloader.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('defaultBrowserCachePath points under .dart_tool/puppeteer when '
+      'running inside a Dart project', () {
+    final path = defaultBrowserCachePath();
+
+    expect(path, isNotNull);
+    expect(p.isAbsolute(path), isTrue,
+        reason: 'expected absolute path, got: $path');
+
+    // When running via `dart test`, Isolate.packageConfigSync is set, so we
+    // should resolve to the workspace's .dart_tool/puppeteer/local-chrome.
+    final segments = p.split(path);
+    final dartToolIdx = segments.lastIndexOf('.dart_tool');
+    expect(dartToolIdx, isNot(-1),
+        reason: 'expected ".dart_tool" segment in path: $path');
+    expect(segments.sublist(dartToolIdx),
+        equals(['.dart_tool', 'puppeteer', 'local-chrome']));
+  });
+
+  test("default path resolves under this project's .dart_tool", () {
+    final path = defaultBrowserCachePath();
+    final projectDartTool = Directory(
+      p.join(Directory.current.path, '.dart_tool'),
+    );
+    // The path should be under the project root's .dart_tool (in this repo
+    // there's no parent workspace, so packageConfig resolves to our own).
+    expect(p.isWithin(projectDartTool.path, path), isTrue,
+        reason:
+            '$path should be inside ${projectDartTool.path}');
+  });
+}


### PR DESCRIPTION
The `downloadChrome` function's default `cachePath` now aligns with Dart's project-specific tool caching convention. It resolves to `.dart_tool/puppeteer/local-chrome/` under the current Dart project or workspace root, providing a unified cache location.

For AOT-compiled binaries where no package config is available, the cache path falls back to an OS-appropriate user cache directory (e.g., `~/Library/Caches/puppeteer` on macOS, `~/.cache/puppeteer` on Linux, `%LOCALAPPDATA%\puppeteer` on Windows).

This improves the consistency and robustness of browser caching. Existing `.local-chrome/` directories will need to be deleted manually.

The package version is bumped to `3.23.0`, and the `CHANGELOG.md` is updated to document these changes, as well as the previously implemented concurrent download safety for `downloadChrome`.