### PR TITLE
Fix flaky crash/tracing tests and harden Chrome launch

### DIFF
--- a/lib/src/page/page.dart
+++ b/lib/src/page/page.dart
@@ -999,12 +999,19 @@ function addPageBinding(bindingName) {
   }
 
   void _handleException(ExceptionThrownEvent event) {
+    if (_onErrorController.isClosed) return;
     _onErrorController.add(ClientError(event.exceptionDetails));
   }
 
   void _handleTargetCrashed(void _) {
+    // A renderer crash does not destroy the page target (Chrome shows a "sad
+    // tab" and the page can recover on the next navigation). Match upstream
+    // Puppeteer and only surface the error here — do NOT dispose the page.
+    // Disposing on crash used to race the error delivery against closing
+    // `_onErrorController`, which intermittently turned `page.onError.first`
+    // into a "No element" / timeout failure.
+    if (_onErrorController.isClosed) return;
     _onErrorController.add(ClientError.pageCrashed());
-    Future(() => _dispose('Target crashed'));
   }
 
   Future<void> _onBindingCalled(BindingCalledEvent event) async {

--- a/lib/src/page/tracing.dart
+++ b/lib/src/page/tracing.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import '../../protocol/dev_tools.dart';
 import '../../protocol/io.dart';
+import '../../protocol/tracing.dart' show TraceConfig;
 
 /// You can use [tracing.start] and [tracing.stop] to create a trace file which
 /// can be opened in Chrome DevTools or [timeline viewer](https://chromedevtools.github.io/timeline-viewer/).
@@ -51,12 +52,22 @@ class Tracing {
       categories.add('disabled-by-default-devtools.screenshot');
     }
 
+    var excludedCategories = [
+      for (var category in categories)
+        if (category.startsWith('-')) category.substring(1),
+    ];
+    var includedCategories = [
+      for (var category in categories)
+        if (!category.startsWith('-')) category,
+    ];
+
     _recording = true;
     await _devTools.tracing.start(
       transferMode: 'ReturnAsStream',
-      //TODO(xha): use the new api
-      // ignore: deprecated_member_use_from_same_package
-      categories: categories.join(','),
+      traceConfig: TraceConfig(
+        includedCategories: includedCategories,
+        excludedCategories: excludedCategories,
+      ),
     );
   }
 

--- a/lib/src/puppeteer.dart
+++ b/lib/src/puppeteer.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'package:http/http.dart';
@@ -256,6 +257,9 @@ class Puppeteer {
 
       return browser;
     } else {
+      // Never connected within the timeout: don't leave an orphaned Chrome
+      // (and let `_waitForWebSocketUrl` tear down its stream subscriptions).
+      await _killChrome(chromeProcess);
       throw Exception('Not able to connect to Chrome DevTools');
     }
   }
@@ -375,20 +379,57 @@ Future<int> _killChrome(Process process) {
 
 final _devToolRegExp = RegExp(r'^DevTools listening on (ws://.*)$');
 
-Future<String> _waitForWebSocketUrl(Process chromeProcess) async {
+Future<String> _waitForWebSocketUrl(Process chromeProcess) {
+  var completer = Completer<String>();
   var accumulatedLines = <String>[];
-  await for (String line
-      in chromeProcess.stderr
-          .transform(Utf8Decoder())
-          .transform(LineSplitter())) {
-    accumulatedLines.add(line);
-    _logger.warning('[Chrome stderr]: $line');
-    var match = _devToolRegExp.firstMatch(line);
-    if (match != null) {
-      return match.group(1)!;
-    }
-  }
-  throw Exception('Websocket url not found.\n${accumulatedLines.join('\n')}');
+
+  // Drain both stdout and stderr for the lifetime of the process. An undrained
+  // pipe blocks Chrome once it fills the ~64KB OS buffer (stdout is otherwise
+  // never read), and keeping stderr drained preserves Chrome's post-handshake
+  // output (warnings, crash reasons) instead of discarding it.
+  Stream<String> lines(Stream<List<int>> stream) => stream
+      .transform(const Utf8Decoder(allowMalformed: true))
+      .transform(const LineSplitter());
+
+  var subscriptions = [
+    lines(chromeProcess.stderr).listen(
+      (line) {
+        if (completer.isCompleted) {
+          _logger.finer('[Chrome stderr]: $line');
+          return;
+        }
+        accumulatedLines.add(line);
+        _logger.warning('[Chrome stderr]: $line');
+        var match = _devToolRegExp.firstMatch(line);
+        if (match != null) completer.complete(match.group(1)!);
+      },
+      onError: (Object error) {
+        if (!completer.isCompleted) completer.completeError(error);
+      },
+      cancelOnError: false,
+    ),
+    lines(chromeProcess.stdout).listen(
+      (line) => _logger.finer('[Chrome stdout]: $line'),
+      onError: (Object _) {},
+      cancelOnError: false,
+    ),
+  ];
+
+  // When Chrome exits, stop draining and fail the wait if it never connected.
+  unawaited(
+    chromeProcess.exitCode.then((_) async {
+      for (var subscription in subscriptions) {
+        await subscription.cancel();
+      }
+      if (!completer.isCompleted) {
+        completer.completeError(
+          Exception('Websocket url not found.\n${accumulatedLines.join('\n')}'),
+        );
+      }
+    }),
+  );
+
+  return completer.future;
 }
 
 Future<String> _inferExecutablePath() async {

--- a/test/page_test.dart
+++ b/test/page_test.dart
@@ -118,16 +118,29 @@ void main() {
     });
   });
   group('Page.Events.error', () {
-    test('should throw when page crashes', () async {
-      var onErrorFuture = page.onError.first;
-
-      await page
-          .goto('chrome://crash')
-          .then<Response?>((e) => e)
-          .catchError((_) => null);
-      var error = await onErrorFuture;
-      expect(error.message, 'Page crashed!');
-    });
+    test(
+      'should throw when page crashes',
+      () async {
+        // Under CI load the `Inspector.targetCrashed` event can be delivered
+        // late (queued behind a starved event loop), and Chrome destroys the
+        // target a few seconds after a renderer crash — which closes
+        // `page.onError`. Use a persistent listener (so a late close does not
+        // surface as "Bad state: No element" the way `.first` does) and a
+        // generous timeout (so a delayed-but-not-lost event still passes).
+        var crashError = Completer<ClientError>();
+        var subscription = page.onError.listen((e) {
+          if (!crashError.isCompleted) crashError.complete(e);
+        });
+        await page
+            .goto('chrome://crash')
+            .then<Response?>((e) => e)
+            .catchError((_) => null);
+        var error = await crashError.future;
+        await subscription.cancel();
+        expect(error.message, 'Page crashed!');
+      },
+      timeout: const Timeout(Duration(seconds: 60)),
+    );
   });
   group('Page.Events.Popup', () {
     test('should work', () async {

--- a/test/tracing_test.dart
+++ b/test/tracing_test.dart
@@ -38,23 +38,19 @@ void main() {
       await page.tracing.stop(result);
       expect(result.toString().length, greaterThan(0));
     });
-    test(
-      'should run with custom categories if provided',
-      () async {
-        await page.tracing.start(
-          categories: ['disabled-by-default-v8.cpu_profiler.hires'],
-        );
-        var buffer = StringBuffer();
-        await page.tracing.stop(buffer);
-        var traceJson = jsonDecode(buffer.toString()) as Map<String, dynamic>;
+    test('should run with custom categories if provided', () async {
+      await page.tracing.start(
+        categories: ['-*', 'disabled-by-default-devtools.timeline.frame'],
+      );
+      var buffer = StringBuffer();
+      await page.tracing.stop(buffer);
+      var traceJson = jsonDecode(buffer.toString()) as Map<String, dynamic>;
+      var events = traceJson['traceEvents'] as List;
 
-        expect(
-          (traceJson['metadata'] as Map<String, dynamic>)['trace-config'],
-          contains('disabled-by-default-v8.cpu_profiler.hires'),
-        );
-      },
-      skip: 'Not working anymore: should investigate',
-    );
+      // Excluding all categories with '-*' must actually take effect: the
+      // 'toplevel' category is present by default but should be absent here.
+      expect(events.any((e) => (e as Map)['cat'] == 'toplevel'), isFalse);
+    });
     test('should throw if tracing on two pages', () async {
       await page.tracing.start();
       var newPage = await browser.newPage();


### PR DESCRIPTION
Three independent fixes that came out of investigating CI flakiness and disabled tests. Each is its own commit.

## 1. Tracing custom categories (`tracing.dart`) — clean win
`Tracing.start` still passed the **deprecated** CDP `categories` string, which modern Chrome ignores — so custom trace categories silently had no effect. Switched to `traceConfig` with included/excluded category lists (handling the `-` exclude prefix, e.g. the default `-*`).

The disabled *"should run with custom categories if provided"* test asserted on `metadata['trace-config']`, a field Chrome **removed** when tracing moved to the Perfetto backend (the real reason it "stopped working since v132"). Re-enabled it with the metadata-independent assertion upstream Puppeteer now uses: exclude all categories with `-*`, then verify no `toplevel` events appear.

## 2. Don't dispose the page on renderer crash (`page.dart`) — targets a CI flake
`_handleTargetCrashed` disposed the page on crash, closing `_onErrorController` and racing delivery of the `"Page crashed!"` error against the stream closing. That intermittently turned `page.onError.first` into a `Bad state: No element` / 30s-timeout failure — the *"Events.error should throw when page crashes"* flake seen in CI.

A renderer crash does **not** destroy the page target (Chrome shows a sad tab; the page can recover), so this matches upstream `CdpPage`, which only emits the error and does not dispose. Disposal still happens on the genuine teardown paths (`onClose`, `browser.disconnected`). Also added guards against `add`-after-close on the error controllers to avoid an unhandled `StateError` from late events.

> Note: I could not reproduce this flake locally (it needs CI's contended event loop), so this is an upstream-parity fix that removes the concrete race — verification is the next CI run, not a local repro.

## 3. Drain Chrome stdout/stderr for the process lifetime (`puppeteer.dart`) — hardening
The launcher stopped reading stderr once the WebSocket URL appeared and never read stdout at all. An undrained OS pipe blocks the writer once it fills (~64KB), so a Chrome build/flag logging to stdout could deadlock the browser. Now drains both pipes for the process lifetime (also preserving Chrome's post-handshake diagnostics), ties the subscriptions to process exit, and kills the orphaned process on the connect-timeout path instead of leaking it.

> This is robustness/observability hardening, not a proven flake fix — the original stderr handling happened to be deadlock-safe (cancelling the subscription closes the fd), but stdout was a genuine latent risk and the timeout path leaked the process.

## Testing
- `dart analyze` clean on all changed files.
- `test/launcher_test.dart` and `test/tracing_test.dart` pass.
- The crash test passes (49 local runs across sequential + parallel-contended).
- Full `test/page_test.dart` regression: only failure is a pre-existing, unrelated `Target.page` null-check on popup targets (fails identically on master) — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)