### PR TITLE
Fix detached-iframes console test for Chrome 149 target drift + clearer Target.page error

### DIFF
--- a/lib/src/target.dart
+++ b/lib/src/target.dart
@@ -98,7 +98,16 @@ class Target {
         : null;
   }
 
-  Future<Page> get page async => (await pageOrNull)!;
+  Future<Page> get page async {
+    var page = await pageOrNull;
+    if (page == null) {
+      throw StateError(
+        'Target of type "$type" (url: $url) is not a page. '
+        'Use `pageOrNull` to handle non-page targets.',
+      );
+    }
+    return page;
+  }
 
   bool get isPage => _isPageTarget(_info);
 

--- a/test/page_test.dart
+++ b/test/page_test.dart
@@ -525,11 +525,11 @@ void main() {
       // 3. After that, remove the iframe.
       frame.remove();
       }''');
-        var popupTarget = page.browserContext.targets.firstWhere(
-          (target) => target != page.target,
-        );
-        // 4. Connect to the popup and make sure it doesn't throw.
-        await popupTarget.page;
+        // 4. The target will always be the last one.
+        var popupTarget = page.browserContext.targets.last;
+        // 5. Connect to the popup and make sure it doesn't throw and is not the
+        // same page.
+        expect(await popupTarget.page, isNot(page));
       },
     );
   });


### PR DESCRIPTION
## Problem

`test/page_test.dart` → *Page.Events.Console should not throw when there are console messages in detached iframes* fails consistently on master (Chrome 149), independent of recent changes:

```
Null check operator used on a null value
package:puppeteer/src/target.dart 101:52  Target.page
```

## Root cause — Chrome-version drift

Chrome 149 attaches a new target to the browser context: type `browser_ui`, url `chrome://webui-toolbar.top-chrome/`, with `subtype = null`. Because its subtype is null and its type isn't `tab`, it passes the standard exposure filter and now shows up in `browserContext.targets` **before** the popup page:

```
[ browser_ui (chrome://webui-toolbar...),  page (main),  page (popup) ]
```

The test selected the popup with `targets.firstWhere((t) => t != page.target)`, which now grabs the `browser_ui` target. `Target.page` (`(await pageOrNull)!`) then throws because `_isPageTarget` is false for `browser_ui`.

## Fixes

**1. Test (root cause).** Mirrors how upstream puppeteer fixed the same drift. Upstream's `_isTargetExposed` still exposes `browser_ui` (no subtype, not a `tab`), so the exposure behavior is left unchanged; only the test's target-selection assumption was stale. Upstream now selects the **last** target (the popup is always created last):

```js
// 4. The target will always be the last one.
const popupTarget = page.browserContext().targets().at(-1)!;
expect(await popupTarget.page()).not.toBe(page);
```

Applied the equivalent in the dart test: `targets.last` + assert it resolves to a `Page` distinct from the opener.

**2. Clearer `Target.page` error (hardening).** `Target.page` previously did `(await pageOrNull)!`, which surfaced a cryptic `Null check operator used on a null value` whenever called on a non-page target. It now throws a `StateError` naming the target type and url and pointing to `pageOrNull` for the nullable path. (The dart port keeps the non-nullable `page` / nullable `pageOrNull` split; this only improves the failure message.)

## Testing

- Confirmed the target type via a temporary debug test: `browser_ui` lands at position 0, popup page is last.
- Target test passes. The only other failure in the `Page.Events.Console` group (`should have location when fetch fails`) is a pre-existing, unrelated network-environment artifact (`fetch('http://wat')` resolves to a 404 here instead of `ERR_NAME_NOT_RESOLVED`) and is not touched by this change.
- `dart analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)