### PR TITLE
Drop web platform to reach pana 160/160 (3.24.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.24.2
+- No longer advertise `web` in the `platforms` metadata. The package still
+  compiles under dart2js for the `puppeteer.connect()` use case, but it depends
+  on `dart:io` and is not WASM-compatible, so `web` is no longer listed as a
+  supported platform. Supported platforms are now Windows, Linux and macOS.
+
 ## 3.24.1
 - Fix `downloadChrome` on Windows: download coordination is now keyed per
   platform, so fetching multiple platforms of the same Chrome version (e.g.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: puppeteer
 description: A high-level API to control headless Chrome over the DevTools Protocol. This is a port of Puppeteer in Dart.
-version: 3.24.1
+version: 3.24.2
 homepage: https://github.com/xvrh/puppeteer-dart
 
 funding:
@@ -10,7 +10,6 @@ funding:
 platforms:
   linux:
   macos:
-  web:
   windows:
 
 environment:


### PR DESCRIPTION
## Why
The published **3.24.1** still scores **150/160** on pub.dev: it advertises the `web` platform while depending on `dart:io`, so the current pana model only grants a *partial* Platform-support score (10/20) for "supports web but not WASM-compatible". (The drop-`web` change was prepared for #473 but landed on the branch after that PR was already merged, so it never shipped.)

## What
Remove `web` from the advertised `platforms` in `pubspec.yaml` → Platform support **20/20 → total 160/160** (verified locally with pana 0.22.23).

The package **still compiles under dart2js** for the `puppeteer.connect()` use case (the `connect_on_web*` tests are unchanged); `web` is simply no longer *advertised* because it cannot compile to WASM. Supported platforms are now Windows, Linux, macOS.

Restoring advertised web support properly (genuine WASM compatibility) is a larger, breaking 4.0.0 effort — it needs conditional-import stubs for the launch/download path and replacing public `dart:io` types (`File`/`Cookie`/`IOSink`).

Release **3.24.2** + CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)