### PR TITLE
WASM-compatible web support + release 3.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 3.25.0
+- The package is now WASM-compatible, so `web` keeps full marks for platform
+  support. `puppeteer.connect()` and page interaction over the DevTools
+  websocket can be compiled to WebAssembly (`dart compile wasm`). Internally,
+  `dart:io` is now reached through a conditional shim that re-exports the real
+  `dart:io` on native platforms (so the public API is unchanged there) and a
+  stub on web/WASM. On web/WASM, `puppeteer.launch()`, `downloadChrome` and the
+  `File`/`IOSink` convenience overloads throw `UnsupportedError` — only
+  `connect()` and CDP-based page interaction are supported.
+
 ## 3.24.1
 - Fix `downloadChrome` on Windows: download coordination is now keyed per
   platform, so fetching multiple platforms of the same Chrome version (e.g.

--- a/lib/src/browser.dart
+++ b/lib/src/browser.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-import 'dart:io';
+import 'io/io.dart';
 import 'package:async/async.dart';
 import 'package:pool/pool.dart';
 import '../plugin.dart';

--- a/lib/src/browser.dart
+++ b/lib/src/browser.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'io/io.dart';
 import 'package:async/async.dart';
 import 'package:pool/pool.dart';
 import '../plugin.dart';
@@ -7,6 +6,7 @@ import '../protocol/browser.dart';
 import '../protocol/system_info.dart';
 import '../protocol/target.dart';
 import 'connection.dart';
+import 'io/io.dart';
 import 'page/emulation_manager.dart';
 import 'page/page.dart';
 import 'target.dart';

--- a/lib/src/browser_path.dart
+++ b/lib/src/browser_path.dart
@@ -1,6 +1,6 @@
-import 'io/io.dart';
 import 'package:path/path.dart' as p;
 import 'downloader.dart';
+import 'io/io.dart';
 
 class BrowserPath {
   static final _chrome = _BrowserPath(

--- a/lib/src/browser_path.dart
+++ b/lib/src/browser_path.dart
@@ -1,4 +1,4 @@
-import 'dart:io';
+import 'io/io.dart';
 import 'package:path/path.dart' as p;
 import 'downloader.dart';
 

--- a/lib/src/downloader.dart
+++ b/lib/src/downloader.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-import 'dart:io';
+import 'io/io.dart';
 import 'dart:isolate';
 import 'package:archive/archive.dart';
 import 'package:http/http.dart' as http;

--- a/lib/src/downloader.dart
+++ b/lib/src/downloader.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
-import 'io/io.dart';
 import 'dart:isolate';
 import 'package:archive/archive.dart';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
+import 'io/io.dart';
 
 const _lastVersion = '150.0.7871.24';
 

--- a/lib/src/io/io.dart
+++ b/lib/src/io/io.dart
@@ -1,0 +1,13 @@
+/// Conditional `dart:io` shim.
+///
+/// On native platforms this re-exports the real `dart:io`, so the public API is
+/// byte-for-byte identical (`File`, `IOSink`, `Process`, ... are the genuine
+/// `dart:io` types). On the web/WASM compilation targets — where `dart:io`
+/// would make the package non-WASM-compatible — it resolves to [io_stub.dart],
+/// which provides the same surface but throws `UnsupportedError` for anything
+/// that needs a filesystem or a process. `puppeteer.connect()` and page
+/// interaction over the DevTools websocket work; `puppeteer.launch()` and the
+/// `File`/`IOSink` convenience overloads do not.
+library;
+
+export 'io_native.dart' if (dart.library.js_interop) 'io_stub.dart';

--- a/lib/src/io/io_native.dart
+++ b/lib/src/io/io_native.dart
@@ -1,0 +1,1 @@
+export 'dart:io';

--- a/lib/src/io/io_stub.dart
+++ b/lib/src/io/io_stub.dart
@@ -1,0 +1,240 @@
+/// Web/WASM stub for the subset of `dart:io` used by this package.
+///
+/// These types exist so `package:puppeteer/puppeteer.dart` compiles to WASM.
+/// Only `connect()` and DevTools-protocol page interaction are usable on the
+/// web; anything that needs a real filesystem or a child process throws
+/// [UnsupportedError]. Path-only helpers (`File.path`, `File.absolute`,
+/// `parent`) work so callers can still build/inspect paths.
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+Never _unsupported(String what) =>
+    throw UnsupportedError('$what is not supported on the web/WASM platform');
+
+class Platform {
+  Platform._();
+
+  static Map<String, String> get environment =>
+      _unsupported('Platform.environment');
+  static bool get isWindows => false;
+  static bool get isMacOS => false;
+  static bool get isLinux => false;
+  static String get operatingSystem => _unsupported('Platform.operatingSystem');
+  static String get version => _unsupported('Platform.version');
+  static String get resolvedExecutable =>
+      _unsupported('Platform.resolvedExecutable');
+  static String get pathSeparator => '/';
+  static int get numberOfProcessors =>
+      _unsupported('Platform.numberOfProcessors');
+}
+
+class OSError {
+  final String message;
+  final int errorCode;
+  const OSError([this.message = '', this.errorCode = 0]);
+  @override
+  String toString() => 'OS Error: $message, errno = $errorCode';
+}
+
+class IOException implements Exception {}
+
+class FileSystemException implements IOException {
+  final String message;
+  final String? path;
+  final OSError? osError;
+  const FileSystemException([this.message = '', this.path, this.osError]);
+  @override
+  String toString() =>
+      'FileSystemException: $message${path == null ? '' : ', path = $path'}';
+}
+
+class PathExistsException extends FileSystemException {
+  const PathExistsException([super.message, super.path, super.osError]);
+}
+
+class PathNotFoundException extends FileSystemException {
+  const PathNotFoundException([super.message, super.path, super.osError]);
+}
+
+class ProcessException implements IOException {
+  final String executable;
+  final List<String> arguments;
+  final String message;
+  final int errorCode;
+  const ProcessException(
+    this.executable,
+    this.arguments, [
+    this.message = '',
+    this.errorCode = 0,
+  ]);
+  @override
+  String toString() => 'ProcessException: $message';
+}
+
+abstract class FileSystemEntity {
+  String get path;
+  FileSystemEntity get absolute;
+  Directory get parent => Directory(path);
+  bool existsSync() => false;
+  Future<bool> exists() async => false;
+  void deleteSync({bool recursive = false}) => _unsupported('delete');
+  Future<FileSystemEntity> delete({bool recursive = false}) =>
+      _unsupported('delete');
+  FileStat statSync() => _unsupported('statSync');
+
+  static bool isFileSync(String path) => false;
+  static bool isDirectorySync(String path) => false;
+}
+
+class File extends FileSystemEntity {
+  @override
+  final String path;
+  File(this.path);
+
+  @override
+  File get absolute => this;
+
+  Future<String> readAsString({Encoding encoding = utf8}) =>
+      _unsupported('File.readAsString');
+  String readAsStringSync({Encoding encoding = utf8}) =>
+      _unsupported('File.readAsStringSync');
+  Future<Uint8List> readAsBytes() => _unsupported('File.readAsBytes');
+  Uint8List readAsBytesSync() => _unsupported('File.readAsBytesSync');
+  Stream<List<int>> openRead([int? start, int? end]) =>
+      _unsupported('File.openRead');
+  IOSink openWrite({
+    FileMode mode = FileMode.write,
+    Encoding encoding = utf8,
+  }) => _unsupported('File.openWrite');
+  Future<File> writeAsBytes(
+    List<int> bytes, {
+    FileMode mode = FileMode.write,
+    bool flush = false,
+  }) => _unsupported('File.writeAsBytes');
+  void writeAsBytesSync(
+    List<int> bytes, {
+    FileMode mode = FileMode.write,
+    bool flush = false,
+  }) => _unsupported('File.writeAsBytesSync');
+  Future<File> writeAsString(
+    String contents, {
+    FileMode mode = FileMode.write,
+    Encoding encoding = utf8,
+    bool flush = false,
+  }) => _unsupported('File.writeAsString');
+  Future<File> create({bool recursive = false, bool exclusive = false}) =>
+      _unsupported('File.create');
+  void createSync({bool recursive = false, bool exclusive = false}) =>
+      _unsupported('File.createSync');
+  @override
+  Future<File> delete({bool recursive = false}) => _unsupported('File.delete');
+  Future<File> rename(String newPath) => _unsupported('File.rename');
+  File renameSync(String newPath) => _unsupported('File.renameSync');
+  Future<int> length() => _unsupported('File.length');
+  int lengthSync() => _unsupported('File.lengthSync');
+}
+
+class Directory extends FileSystemEntity {
+  @override
+  final String path;
+  Directory(this.path);
+
+  static Directory get current => _unsupported('Directory.current');
+  static Directory get systemTemp => _unsupported('Directory.systemTemp');
+
+  @override
+  Directory get absolute => this;
+  void createSync({bool recursive = false}) =>
+      _unsupported('Directory.createSync');
+  Future<Directory> create({bool recursive = false}) =>
+      _unsupported('Directory.create');
+  Directory createTempSync([String? prefix]) =>
+      _unsupported('Directory.createTempSync');
+  Future<Directory> createTemp([String? prefix]) =>
+      _unsupported('Directory.createTemp');
+  @override
+  Future<Directory> delete({bool recursive = false}) =>
+      _unsupported('Directory.delete');
+  List<FileSystemEntity> listSync({
+    bool recursive = false,
+    bool followLinks = true,
+  }) => _unsupported('Directory.listSync');
+  Future<Directory> rename(String newPath) => _unsupported('Directory.rename');
+}
+
+class FileStat {
+  DateTime get modified => _unsupported('FileStat.modified');
+  int get size => _unsupported('FileStat.size');
+}
+
+class FileMode {
+  final int mode;
+  const FileMode._(this.mode);
+  static const read = FileMode._(0);
+  static const write = FileMode._(1);
+  static const append = FileMode._(2);
+  static const writeOnly = FileMode._(3);
+  static const writeOnlyAppend = FileMode._(4);
+}
+
+class ProcessSignal {
+  final String _name;
+  const ProcessSignal._(this._name);
+  static const sigkill = ProcessSignal._('SIGKILL');
+  static const sigterm = ProcessSignal._('SIGTERM');
+  @override
+  String toString() => _name;
+}
+
+class ProcessResult {
+  final int pid;
+  final int exitCode;
+  final dynamic stdout;
+  final dynamic stderr;
+  ProcessResult(this.pid, this.exitCode, this.stdout, this.stderr);
+}
+
+abstract class Process {
+  int get pid;
+  Future<int> get exitCode;
+  Stream<List<int>> get stdout;
+  Stream<List<int>> get stderr;
+  IOSink get stdin;
+  bool kill([ProcessSignal signal = ProcessSignal.sigterm]);
+
+  static Future<Process> start(
+    String executable,
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool runInShell = false,
+  }) => _unsupported('Process.start');
+  static Future<ProcessResult> run(
+    String executable,
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool runInShell = false,
+  }) => _unsupported('Process.run');
+  static ProcessResult runSync(
+    String executable,
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool runInShell = false,
+  }) => _unsupported('Process.runSync');
+}
+
+/// Minimal [IOSink]-compatible interface: a `Sink<List<int>>` that is also a
+/// `StringSink`, matching the `dart:io` surface the package relies on.
+abstract class IOSink implements StreamSink<List<int>>, StringSink {
+  Encoding encoding = utf8;
+}
+
+IOSink get stdout => _unsupported('stdout');
+IOSink get stderr => _unsupported('stderr');
+
+int exitCode = 0;

--- a/lib/src/page/dom_world.dart
+++ b/lib/src/page/dom_world.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-import 'dart:io';
+import '../io/io.dart';
 import '../javascript_function_parser.dart';
 import 'execution_context.dart';
 import 'frame_manager.dart';

--- a/lib/src/page/frame_manager.dart
+++ b/lib/src/page/frame_manager.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-import 'dart:io';
+import '../io/io.dart';
 import '../../protocol/network.dart';
 import '../../protocol/page.dart';
 import '../../protocol/runtime.dart';

--- a/lib/src/page/frame_manager.dart
+++ b/lib/src/page/frame_manager.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
-import '../io/io.dart';
 import '../../protocol/network.dart';
 import '../../protocol/page.dart';
 import '../../protocol/runtime.dart';
 import '../connection.dart';
+import '../io/io.dart';
 import 'dom_world.dart';
 import 'execution_context.dart';
 import 'js_handle.dart';

--- a/lib/src/page/helper.dart
+++ b/lib/src/page/helper.dart
@@ -1,8 +1,8 @@
 import 'dart:convert';
-import '../io/io.dart';
 import 'package:logging/logging.dart';
 import '../../protocol/io.dart';
 import '../../protocol/runtime.dart';
+import '../io/io.dart';
 import '../javascript_function_parser.dart';
 
 final _logger = Logger('puppeteer.helper');

--- a/lib/src/page/helper.dart
+++ b/lib/src/page/helper.dart
@@ -1,5 +1,5 @@
 import 'dart:convert';
-import 'dart:io';
+import '../io/io.dart';
 import 'package:logging/logging.dart';
 import '../../protocol/io.dart';
 import '../../protocol/runtime.dart';

--- a/lib/src/page/js_handle.dart
+++ b/lib/src/page/js_handle.dart
@@ -1,4 +1,4 @@
-import 'dart:io';
+import '../io/io.dart';
 import 'dart:math';
 import '../../protocol/dom.dart';
 import '../../protocol/input.dart';

--- a/lib/src/page/js_handle.dart
+++ b/lib/src/page/js_handle.dart
@@ -1,9 +1,9 @@
-import '../io/io.dart';
 import 'dart:math';
 import '../../protocol/dom.dart';
 import '../../protocol/input.dart';
 import '../../protocol/runtime.dart';
 import '../connection.dart';
+import '../io/io.dart';
 import 'execution_context.dart';
 import 'frame_manager.dart';
 import 'helper.dart';

--- a/lib/src/page/page.dart
+++ b/lib/src/page/page.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
+import '../io/io.dart';
 import 'dart:math';
 import 'dart:typed_data';
 import 'package:async/async.dart';

--- a/lib/src/page/page.dart
+++ b/lib/src/page/page.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import '../io/io.dart';
 import 'dart:math';
 import 'dart:typed_data';
 import 'package:async/async.dart';
@@ -16,6 +15,7 @@ import '../../protocol/runtime.dart';
 import '../../protocol/target.dart';
 import '../browser.dart';
 import '../connection.dart';
+import '../io/io.dart';
 import '../target.dart';
 import '../utils/take_until.dart';
 import 'accessibility.dart';

--- a/lib/src/puppeteer.dart
+++ b/lib/src/puppeteer.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
+import 'io/io.dart';
 import 'package:http/http.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;

--- a/lib/src/puppeteer.dart
+++ b/lib/src/puppeteer.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'io/io.dart';
 import 'package:http/http.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
@@ -10,6 +9,7 @@ import 'connection.dart';
 import 'devices.dart';
 import 'devices.dart' as devices_lib;
 import 'downloader.dart';
+import 'io/io.dart';
 import 'page/emulation_manager.dart';
 import 'plugin.dart';
 import 'target.dart';

--- a/lib/src/websocket.dart
+++ b/lib/src/websocket.dart
@@ -1,4 +1,6 @@
-import 'websocket_io.dart' if (dart.library.html) 'websocket_html.dart' as ws;
+import 'websocket_io.dart'
+    if (dart.library.js_interop) 'websocket_html.dart'
+    as ws;
 
 abstract class WebSocket {
   static Future<WebSocket> connect(String url) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: puppeteer
 description: A high-level API to control headless Chrome over the DevTools Protocol. This is a port of Puppeteer in Dart.
-version: 3.24.1
+version: 3.25.0
 homepage: https://github.com/xvrh/puppeteer-dart
 
 funding:

--- a/test/connect_on_web_directly_test.dart
+++ b/test/connect_on_web_directly_test.dart
@@ -10,6 +10,113 @@ import 'package:test/test.dart';
 
 // Test that we can use puppeteer.connect from a web page (dart compiled with Dart2js)
 void main() {
+  // Guards WASM compatibility: `puppeteer.connect()` and the page API must stay
+  // reachable without `dart:io` (which would otherwise leak in via the
+  // web-unreachable launch/download paths). If this fails, a `dart:io` import
+  // crept into the web-reachable graph — use `lib/src/io/io.dart` instead.
+  test('connect() entrypoint compiles to WASM', () async {
+    var tempDirectory = Directory.systemTemp.createTempSync();
+    try {
+      var wasmFile = p.join(tempDirectory.path, 'script.wasm');
+      var compileResult = await Process.run(Platform.resolvedExecutable, [
+        'compile',
+        'wasm',
+        '--output',
+        wasmFile,
+        'test/connect_on_web_part.dart',
+      ]);
+      expect(
+        compileResult.exitCode,
+        0,
+        reason:
+            'Compiling the connect() entrypoint to WASM failed. A `dart:io` '
+            'import likely leaked into the web-reachable graph.\n'
+            '${compileResult.stdout}\n${compileResult.stderr}',
+      );
+      expect(File(wasmFile).existsSync(), isTrue);
+    } finally {
+      tempDirectory.deleteSync(recursive: true);
+    }
+  }, timeout: Timeout.factor(6));
+
+  test('Can use puppeteer on the web compiled to WASM', () async {
+    var browser = await puppeteer.launch(args: ['--remote-allow-origins=*']);
+    var tempDirectory = Directory.systemTemp.createTempSync();
+
+    String contentTypeFor(String path) {
+      if (path.endsWith('.wasm')) return 'application/wasm';
+      if (path.endsWith('.mjs') || path.endsWith('.js')) {
+        return 'text/javascript';
+      }
+      return 'application/octet-stream';
+    }
+
+    var httpServer = await shelf.serve(
+      (request) async {
+        var uri = request.requestedUri;
+        if (uri.path == '/index.html') {
+          return shelf.Response.ok(
+            '''
+<html>
+  <head><title>Puppeteer</title></head>
+  <body x-puppeteer-endpoint="${browser.wsEndpoint}">
+    <h1>Puppeteer</h1>
+    <script type="module">
+      import { compile } from '/script.mjs';
+      const bytes = await (await fetch('/script.wasm')).arrayBuffer();
+      const app = await compile(bytes);
+      const instantiated = await app.instantiate({});
+      instantiated.invokeMain();
+    </script>
+  </body>
+</html>
+''',
+            headers: {'content-type': 'text/html'},
+          );
+        } else if (uri.path == '/favicon.ico') {
+          return shelf.Response.ok('');
+        }
+
+        var file = File(p.join(tempDirectory.path, p.basename(uri.path)));
+        if (file.existsSync()) {
+          return shelf.Response.ok(
+            file.readAsBytesSync(),
+            headers: {'content-type': contentTypeFor(uri.path)},
+          );
+        }
+        return shelf.Response.notFound('');
+      },
+      InternetAddress.anyIPv4,
+      0,
+    );
+
+    try {
+      var compileResult = await Process.run(Platform.resolvedExecutable, [
+        'compile',
+        'wasm',
+        '--output',
+        p.join(tempDirectory.path, 'script.wasm'),
+        'test/connect_on_web_part.dart',
+      ]);
+      expect(
+        compileResult.exitCode,
+        0,
+        reason: '${compileResult.stdout}\n${compileResult.stderr}',
+      );
+
+      var page = await browser.newPage();
+      await page.goto('http://localhost:${httpServer.port}/index.html');
+
+      await page.onConsole.firstWhere(
+        (e) => e.text == 'Hello from puppeteer in js',
+      );
+    } finally {
+      await httpServer.close();
+      tempDirectory.deleteSync(recursive: true);
+      await browser.close();
+    }
+  }, timeout: Timeout.factor(6));
+
   test('Can use puppeteer on the web (directly)', () async {
     var browser = await puppeteer.launch(args: ['--remote-allow-origins=*']);
     var tempDirectory = Directory.systemTemp.createTempSync();


### PR DESCRIPTION
## Summary
Makes the package **WASM-compatible** so `web` keeps full marks for platform support, taking the published pana score from **150/160 → 160/160** while *keeping* web advertised. Non-breaking on native.

This supersedes #474 (which simply dropped `web`): instead of removing the platform, we make it genuinely WASM-ready.

## The fix
The previous 10-point loss was pana's "supports web but not WASM-compatible" partial, caused by `dart:io` being reachable from the web graph.

- **`lib/src/io/io.dart`** — a conditional shim: re-exports the real `dart:io` on native (`io_native.dart`), and a stub (`io_stub.dart`) on web/WASM (`if (dart.library.js_interop)`). On native the public API is byte-for-byte unchanged (`File`/`IOSink`/`Process`/… are the genuine `dart:io` types); on web/WASM the stub throws `UnsupportedError` for anything needing a filesystem or a process.
- Replaced `import 'dart:io'` with the shim in the 9 web-reachable lib files. `websocket_io.dart` stays native-only behind its conditional.
- **Fixed a latent bug** in `websocket.dart`: the conditional used `dart.library.html`, which is *false* on WASM, so WASM wrongly fell back to the `dart:io` socket. Now uses `dart.library.js_interop` (true on dart2js and WASM, false on native).

## Behavior
- **Native (Windows/Linux/macOS):** unchanged. `launch()`, `connect()`, downloads, `File`/`IOSink` APIs all work as before.
- **Web/WASM:** `connect()` + CDP page interaction work; `launch()`/`downloadChrome`/`File`/`IOSink` convenience overloads throw `UnsupportedError` (a browser has no local FS/process — same practical limit web already had, now explicit).

## Tests
Extended `connect_on_web_directly_test.dart`:
- `connect() entrypoint compiles to WASM` — fast guard; fails if a `dart:io` import leaks back into the web graph (verified it fails when reintroduced).
- `Can use puppeteer on the web compiled to WASM` — full end-to-end: compiles to wasm, loads it in headless Chrome via the generated `.mjs`, and the WASM app connects back over the DevTools websocket and drives the page.

Existing dart2js web tests still pass.

## Release
Version **3.25.0** (minor — new capability, non-breaking) + CHANGELOG. Local pana: **160/160** with `platform:web` retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)