### PR TITLE
Fix WASM compatibility (dart:isolate) + pana CI check (3.25.1)

### DIFF
--- a/.github/workflows/pana.yaml
+++ b/.github/workflows/pana.yaml
@@ -1,0 +1,20 @@
+name: Pana
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  pana:
+    name: Check pana score
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: 'stable'
+      - uses: actions/checkout@v4
+      - run: dart pub get
+      - run: dart pub global activate pana
+      - run: dart tool/check_pana.dart

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.25.1
+- Complete WASM compatibility: route `dart:isolate` through the same shim.
+
 ## 3.25.0
 - The package is now WASM-compatible, so `web` keeps full marks for platform
   support. `puppeteer.connect()` and page interaction over the DevTools

--- a/lib/src/downloader.dart
+++ b/lib/src/downloader.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:isolate';
 import 'package:archive/archive.dart';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
@@ -31,7 +30,7 @@ class DownloadedBrowserInfo {
 /// When no package config is available — which is the case for AOT-compiled
 /// executables — this falls back to an OS-appropriate user cache directory.
 String defaultBrowserCachePath() {
-  final config = Isolate.packageConfigSync;
+  final config = packageConfigSync();
   if (config != null) {
     return config.resolve('puppeteer/local-chrome/').toFilePath();
   }

--- a/lib/src/io/io_native.dart
+++ b/lib/src/io/io_native.dart
@@ -1,1 +1,6 @@
+import 'dart:isolate';
+
 export 'dart:io';
+
+/// The package config URI for the running program, or `null` if unavailable.
+Uri? packageConfigSync() => Isolate.packageConfigSync;

--- a/lib/src/io/io_stub.dart
+++ b/lib/src/io/io_stub.dart
@@ -238,3 +238,6 @@ IOSink get stdout => _unsupported('stdout');
 IOSink get stderr => _unsupported('stderr');
 
 int exitCode = 0;
+
+/// No package config is available on the web/WASM platform.
+Uri? packageConfigSync() => null;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: puppeteer
 description: A high-level API to control headless Chrome over the DevTools Protocol. This is a port of Puppeteer in Dart.
-version: 3.25.0
+version: 3.25.1
 homepage: https://github.com/xvrh/puppeteer-dart
 
 funding:

--- a/tool/check_pana.dart
+++ b/tool/check_pana.dart
@@ -1,0 +1,76 @@
+import 'dart:convert';
+import 'dart:io';
+
+/// Runs `pana` and fails if the package no longer earns a perfect pub.dev
+/// score, printing the breakdown of any section that lost points.
+///
+/// This catches regressions that other CI steps miss — e.g. a stray
+/// `dart:io`/`dart:isolate` import that drops WASM/platform support, an
+/// outdated dependency constraint, a documentation/convention gap — anything
+/// pana scores. (`dart compile wasm` can't guard the platform score because it
+/// tree-shakes unreachable imports; pana's static analysis does not.)
+Future<void> main() async {
+  final result = await Process.run('dart', [
+    'pub',
+    'global',
+    'run',
+    'pana',
+    '--no-warning',
+    '--json',
+    '.',
+  ]);
+  if (result.exitCode != 0) {
+    stderr.writeln(result.stderr);
+    stderr.writeln('pana exited with ${result.exitCode}');
+    exit(1);
+  }
+
+  final report = _extractJson(result.stdout as String);
+  final tags = ((report['tags'] as List?) ?? const []).cast<String>();
+  final scores = (report['scores'] as Map?) ?? const {};
+  final granted = scores['grantedPoints'];
+  final max = scores['maxPoints'];
+  final sections =
+      (((report['report'] as Map?)?['sections'] as List?) ?? const [])
+          .cast<Map<String, dynamic>>();
+
+  stdout.writeln('pana score: $granted / $max');
+  stdout.writeln('tags: ${tags.join(', ')}');
+  for (final section in sections) {
+    stdout.writeln(
+      '  [${section['grantedPoints']}/${section['maxPoints']}] '
+      '${section['title']}',
+    );
+  }
+
+  if (granted == max) {
+    stdout.writeln('\nPana check passed: perfect $max/$max score.');
+    return;
+  }
+
+  stderr.writeln(
+    '\nPana check FAILED: score is $granted/$max (expected $max).',
+  );
+  for (final section in sections) {
+    if (section['grantedPoints'] != section['maxPoints']) {
+      stderr.writeln(
+        '\n=== [${section['grantedPoints']}/${section['maxPoints']}] '
+        '${section['title']} ===',
+      );
+      stderr.writeln(section['summary']);
+    }
+  }
+  exit(1);
+}
+
+/// pana prints dependency-resolution noise before the JSON report; grab the
+/// report object (the first line that is exactly `{`).
+Map<String, dynamic> _extractJson(String output) {
+  final lines = const LineSplitter().convert(output);
+  final start = lines.indexWhere((l) => l.trim() == '{');
+  if (start < 0) {
+    stderr.writeln('Could not find JSON report in pana output.');
+    exit(1);
+  }
+  return jsonDecode(lines.sublist(start).join('\n')) as Map<String, dynamic>;
+}


### PR DESCRIPTION
## Why
Published **3.25.0 still scores 150/160** on pub.dev. `downloader.dart` imported `dart:isolate` (for `Isolate.packageConfigSync` in the cache-path lookup) unconditionally, so it stayed in the web-reachable graph and `dart:isolate` isn't WASM-compatible → pana dropped **Platform support to 10/20**.

This was missed because (a) the local pana was stale — pub.dev uses 0.23.12, which flags `dart:isolate`; and (b) the WASM **compile** test tree-shakes the unreachable code, so it compiled clean.

## Fix
Route `Isolate.packageConfigSync` through the existing conditional `dart:io` shim: real implementation on native (`io_native.dart`), `null` on web/WASM (`io_stub.dart`). `downloader.dart` drops `import 'dart:isolate'`.

Verified with pana 0.23.12: **160/160**, `is:wasm-ready` + `platform:web` retained, WASM still compiles.

## CI guard
- `tool/check_pana.dart` — runs pana and fails on **any** sub-160 score, printing the breakdown of each section that lost points. Cross-platform (pure Dart). Negative-control verified (fails when the leak is reintroduced).
- `.github/workflows/pana.yaml` — runs it on PRs and master pushes.

Release **3.25.1** (patch) + ultra-light CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)