### PR TITLE
Fix analyzer warnings from Dart 3.13

### DIFF
--- a/lib/src/page/frame_manager.dart
+++ b/lib/src/page/frame_manager.dart
@@ -122,14 +122,15 @@ class FrameManager {
       return null;
     }
 
+    Object? error;
     try {
-      var error = await Future.any([navigate(), watcher.timeoutOrTermination]);
-
-      if (error != null) {
-        return Future.error(error);
-      }
+      error = await Future.any([navigate(), watcher.timeoutOrTermination]);
     } finally {
       watcher.dispose();
+    }
+
+    if (error != null) {
+      return Future.error(error);
     }
 
     return watcher.navigationResponse ??
@@ -147,18 +148,19 @@ class FrameManager {
       wait: wait,
       timeout: timeout ?? page.navigationTimeoutOrDefault,
     );
+    Exception? error;
     try {
-      var error = await Future.any([
+      error = await Future.any([
         watcher.timeoutOrTermination,
         watcher.sameDocumentNavigation,
         watcher.newDocumentNavigation,
       ]);
-
-      if (error != null) {
-        return Future.error(error);
-      }
     } finally {
       watcher.dispose();
+    }
+
+    if (error != null) {
+      return Future.error(error);
     }
 
     return watcher.navigationResponse ??

--- a/test/keyboard_test.dart
+++ b/test/keyboard_test.dart
@@ -33,7 +33,8 @@ void main() {
     expect(Key.allKeys['Control'], Key.control);
     expect(Key.allKeys['notexist'], isNull);
     expect(Key.allKeys[''], isNull);
-    expect(Key.allKeys[null], isNull);
+    String? nullKey;
+    expect(Key.allKeys[nullKey], isNull);
 
     for (var key in Key.allKeys.values) {
       expect(key.toString(), isNotNull);


### PR DESCRIPTION
CI moved to Dart 3.13.0, which adds the `unawaited_return_in_try_block` lint. It fires on the two `return Future.error(error)` statements in `frame_manager.dart`, dropping the pana score to 140/160, and — together with a new `collection_methods_unrelated_type` info on a `null` map lookup in `keyboard_test.dart` — breaks `dart analyze --fatal-infos`. This is what turns every check red on #490 and any other open PR; it is not related to the Chrome roll.

- `frame_manager.dart`: hoist the error return out of the `try` block in `navigateFrame` and `waitForFrameNavigation`. The `await` stays inside, so the `finally` still disposes the watcher before the error surfaces — behaviour is unchanged. `throw error` is not an option because `Future.any` types the value as `Object?` in `navigateFrame`, which `only_throw_errors` rejects.
- `keyboard_test.dart`: pass a `String?` variable instead of a literal `null`, keeping the null-lookup assertion.

Verified against Dart `3.13.0-282.4.beta`: the three issues reproduce on unmodified `master` and are gone after this change. `test/navigation_test.dart` passes (45 passed, 3 skipped), covering the `goto` error/timeout paths and the `waitForNavigation` failure cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)