### PR TITLE
Generate null-aware elements in protocol commands

### DIFF
--- a/.github/workflows/pana.yaml
+++ b/.github/workflows/pana.yaml
@@ -15,6 +15,10 @@ jobs:
         with:
           sdk: 'stable'
       - uses: actions/checkout@v4
-      - run: dart pub get
+      # pub.dev analyses the published package against the newest resolvable
+      # versions, ignoring pubspec.lock. Upgrade so this check sees what the
+      # published score will see — e.g. a lint newly added to
+      # package:lints/recommended.yaml.
+      - run: dart pub upgrade
       - run: dart pub global activate pana
       - run: dart tool/check_pana.dart

--- a/lib/protocol/accessibility.dart
+++ b/lib/protocol/accessibility.dart
@@ -53,10 +53,10 @@ class AccessibilityApi {
     bool? fetchRelatives,
   }) async {
     var result = await _client.send('Accessibility.getPartialAXTree', {
-      if (nodeId != null) 'nodeId': nodeId,
-      if (backendNodeId != null) 'backendNodeId': backendNodeId,
-      if (objectId != null) 'objectId': objectId,
-      if (fetchRelatives != null) 'fetchRelatives': fetchRelatives,
+      'nodeId': ?nodeId,
+      'backendNodeId': ?backendNodeId,
+      'objectId': ?objectId,
+      'fetchRelatives': ?fetchRelatives,
     });
     return (result['nodes'] as List)
         .map((e) => AXNodeData.fromJson(e as Map<String, dynamic>))
@@ -73,8 +73,8 @@ class AccessibilityApi {
     page.FrameId? frameId,
   }) async {
     var result = await _client.send('Accessibility.getFullAXTree', {
-      if (depth != null) 'depth': depth,
-      if (frameId != null) 'frameId': frameId,
+      'depth': ?depth,
+      'frameId': ?frameId,
     });
     return (result['nodes'] as List)
         .map((e) => AXNodeData.fromJson(e as Map<String, dynamic>))
@@ -87,7 +87,7 @@ class AccessibilityApi {
   /// If omitted, the root frame is used.
   Future<AXNodeData> getRootAXNode({page.FrameId? frameId}) async {
     var result = await _client.send('Accessibility.getRootAXNode', {
-      if (frameId != null) 'frameId': frameId,
+      'frameId': ?frameId,
     });
     return AXNodeData.fromJson(result['node'] as Map<String, dynamic>);
   }
@@ -103,9 +103,9 @@ class AccessibilityApi {
     runtime.RemoteObjectId? objectId,
   }) async {
     var result = await _client.send('Accessibility.getAXNodeAndAncestors', {
-      if (nodeId != null) 'nodeId': nodeId,
-      if (backendNodeId != null) 'backendNodeId': backendNodeId,
-      if (objectId != null) 'objectId': objectId,
+      'nodeId': ?nodeId,
+      'backendNodeId': ?backendNodeId,
+      'objectId': ?objectId,
     });
     return (result['nodes'] as List)
         .map((e) => AXNodeData.fromJson(e as Map<String, dynamic>))
@@ -122,7 +122,7 @@ class AccessibilityApi {
   }) async {
     var result = await _client.send('Accessibility.getChildAXNodes', {
       'id': id,
-      if (frameId != null) 'frameId': frameId,
+      'frameId': ?frameId,
     });
     return (result['nodes'] as List)
         .map((e) => AXNodeData.fromJson(e as Map<String, dynamic>))
@@ -149,11 +149,11 @@ class AccessibilityApi {
     String? role,
   }) async {
     var result = await _client.send('Accessibility.queryAXTree', {
-      if (nodeId != null) 'nodeId': nodeId,
-      if (backendNodeId != null) 'backendNodeId': backendNodeId,
-      if (objectId != null) 'objectId': objectId,
-      if (accessibleName != null) 'accessibleName': accessibleName,
-      if (role != null) 'role': role,
+      'nodeId': ?nodeId,
+      'backendNodeId': ?backendNodeId,
+      'objectId': ?objectId,
+      'accessibleName': ?accessibleName,
+      'role': ?role,
     });
     return (result['nodes'] as List)
         .map((e) => AXNodeData.fromJson(e as Map<String, dynamic>))

--- a/lib/protocol/audits.dart
+++ b/lib/protocol/audits.dart
@@ -35,8 +35,8 @@ class AuditsApi {
     var result = await _client.send('Audits.getEncodedResponse', {
       'requestId': requestId,
       'encoding': encoding,
-      if (quality != null) 'quality': quality,
-      if (sizeOnly != null) 'sizeOnly': sizeOnly,
+      'quality': ?quality,
+      'sizeOnly': ?sizeOnly,
     });
     return GetEncodedResponseResult.fromJson(result);
   }

--- a/lib/protocol/autofill.dart
+++ b/lib/protocol/autofill.dart
@@ -28,9 +28,9 @@ class AutofillApi {
   }) async {
     await _client.send('Autofill.trigger', {
       'fieldId': fieldId,
-      if (frameId != null) 'frameId': frameId,
-      if (card != null) 'card': card,
-      if (address != null) 'address': address,
+      'frameId': ?frameId,
+      'card': ?card,
+      'address': ?address,
     });
   }
 

--- a/lib/protocol/bluetooth_emulation.dart
+++ b/lib/protocol/bluetooth_emulation.dart
@@ -118,15 +118,13 @@ class BluetoothEmulationApi {
     int code, {
     String? data,
   }) async {
-    await _client.send(
-      'BluetoothEmulation.simulateCharacteristicOperationResponse',
-      {
-        'characteristicId': characteristicId,
-        'type': type,
-        'code': code,
-        'data': ?data,
-      },
-    );
+    await _client
+        .send('BluetoothEmulation.simulateCharacteristicOperationResponse', {
+          'characteristicId': characteristicId,
+          'type': type,
+          'code': code,
+          'data': ?data,
+        });
   }
 
   /// Simulates the response from the descriptor with |descriptorId| for a

--- a/lib/protocol/bluetooth_emulation.dart
+++ b/lib/protocol/bluetooth_emulation.dart
@@ -118,13 +118,15 @@ class BluetoothEmulationApi {
     int code, {
     String? data,
   }) async {
-    await _client
-        .send('BluetoothEmulation.simulateCharacteristicOperationResponse', {
-          'characteristicId': characteristicId,
-          'type': type,
-          'code': code,
-          if (data != null) 'data': data,
-        });
+    await _client.send(
+      'BluetoothEmulation.simulateCharacteristicOperationResponse',
+      {
+        'characteristicId': characteristicId,
+        'type': type,
+        'code': code,
+        'data': ?data,
+      },
+    );
   }
 
   /// Simulates the response from the descriptor with |descriptorId| for a
@@ -138,13 +140,10 @@ class BluetoothEmulationApi {
     int code, {
     String? data,
   }) async {
-    await _client
-        .send('BluetoothEmulation.simulateDescriptorOperationResponse', {
-          'descriptorId': descriptorId,
-          'type': type,
-          'code': code,
-          if (data != null) 'data': data,
-        });
+    await _client.send(
+      'BluetoothEmulation.simulateDescriptorOperationResponse',
+      {'descriptorId': descriptorId, 'type': type, 'code': code, 'data': ?data},
+    );
   }
 
   /// Adds a service with |serviceUuid| to the peripheral with |address|.

--- a/lib/protocol/browser.dart
+++ b/lib/protocol/browser.dart
@@ -37,9 +37,9 @@ class BrowserApi {
     await _client.send('Browser.setPermission', {
       'permission': permission,
       'setting': setting,
-      if (origin != null) 'origin': origin,
-      if (embeddedOrigin != null) 'embeddedOrigin': embeddedOrigin,
-      if (browserContextId != null) 'browserContextId': browserContextId,
+      'origin': ?origin,
+      'embeddedOrigin': ?embeddedOrigin,
+      'browserContextId': ?browserContextId,
     });
   }
 
@@ -55,8 +55,8 @@ class BrowserApi {
   }) async {
     await _client.send('Browser.grantPermissions', {
       'permissions': [...permissions],
-      if (origin != null) 'origin': origin,
-      if (browserContextId != null) 'browserContextId': browserContextId,
+      'origin': ?origin,
+      'browserContextId': ?browserContextId,
     });
   }
 
@@ -64,7 +64,7 @@ class BrowserApi {
   /// [browserContextId] BrowserContext to reset permissions. When omitted, default browser context is used.
   Future<void> resetPermissions({BrowserContextID? browserContextId}) async {
     await _client.send('Browser.resetPermissions', {
-      if (browserContextId != null) 'browserContextId': browserContextId,
+      'browserContextId': ?browserContextId,
     });
   }
 
@@ -87,9 +87,9 @@ class BrowserApi {
     );
     await _client.send('Browser.setDownloadBehavior', {
       'behavior': behavior,
-      if (browserContextId != null) 'browserContextId': browserContextId,
-      if (downloadPath != null) 'downloadPath': downloadPath,
-      if (eventsEnabled != null) 'eventsEnabled': eventsEnabled,
+      'browserContextId': ?browserContextId,
+      'downloadPath': ?downloadPath,
+      'eventsEnabled': ?eventsEnabled,
     });
   }
 
@@ -102,7 +102,7 @@ class BrowserApi {
   }) async {
     await _client.send('Browser.cancelDownload', {
       'guid': guid,
-      if (browserContextId != null) 'browserContextId': browserContextId,
+      'browserContextId': ?browserContextId,
     });
   }
 
@@ -143,8 +143,8 @@ class BrowserApi {
   /// Returns: Histograms.
   Future<List<Histogram>> getHistograms({String? query, bool? delta}) async {
     var result = await _client.send('Browser.getHistograms', {
-      if (query != null) 'query': query,
-      if (delta != null) 'delta': delta,
+      'query': ?query,
+      'delta': ?delta,
     });
     return (result['histograms'] as List)
         .map((e) => Histogram.fromJson(e as Map<String, dynamic>))
@@ -158,7 +158,7 @@ class BrowserApi {
   Future<Histogram> getHistogram(String name, {bool? delta}) async {
     var result = await _client.send('Browser.getHistogram', {
       'name': name,
-      if (delta != null) 'delta': delta,
+      'delta': ?delta,
     });
     return Histogram.fromJson(result['histogram'] as Map<String, dynamic>);
   }
@@ -180,7 +180,7 @@ class BrowserApi {
     target.TargetID? targetId,
   }) async {
     var result = await _client.send('Browser.getWindowForTarget', {
-      if (targetId != null) 'targetId': targetId,
+      'targetId': ?targetId,
     });
     return GetWindowForTargetResult.fromJson(result);
   }
@@ -209,8 +209,8 @@ class BrowserApi {
   }) async {
     await _client.send('Browser.setContentsSize', {
       'windowId': windowId,
-      if (width != null) 'width': width,
-      if (height != null) 'height': height,
+      'width': ?width,
+      'height': ?height,
     });
   }
 
@@ -218,8 +218,8 @@ class BrowserApi {
   /// [image] Png encoded image.
   Future<void> setDockTile({String? badgeLabel, String? image}) async {
     await _client.send('Browser.setDockTile', {
-      if (badgeLabel != null) 'badgeLabel': badgeLabel,
-      if (image != null) 'image': image,
+      'badgeLabel': ?badgeLabel,
+      'image': ?image,
     });
   }
 
@@ -254,7 +254,7 @@ class BrowserApi {
       'api': api,
       'coordinatorOrigin': coordinatorOrigin,
       'keyConfig': keyConfig,
-      if (browserContextId != null) 'browserContextId': browserContextId,
+      'browserContextId': ?browserContextId,
     });
   }
 }

--- a/lib/protocol/cache_storage.dart
+++ b/lib/protocol/cache_storage.dart
@@ -35,9 +35,9 @@ class CacheStorageApi {
     storage.StorageBucket? storageBucket,
   }) async {
     var result = await _client.send('CacheStorage.requestCacheNames', {
-      if (securityOrigin != null) 'securityOrigin': securityOrigin,
-      if (storageKey != null) 'storageKey': storageKey,
-      if (storageBucket != null) 'storageBucket': storageBucket,
+      'securityOrigin': ?securityOrigin,
+      'storageKey': ?storageKey,
+      'storageBucket': ?storageBucket,
     });
     return (result['caches'] as List)
         .map((e) => Cache.fromJson(e as Map<String, dynamic>))
@@ -75,9 +75,9 @@ class CacheStorageApi {
   }) async {
     var result = await _client.send('CacheStorage.requestEntries', {
       'cacheId': cacheId,
-      if (skipCount != null) 'skipCount': skipCount,
-      if (pageSize != null) 'pageSize': pageSize,
-      if (pathFilter != null) 'pathFilter': pathFilter,
+      'skipCount': ?skipCount,
+      'pageSize': ?pageSize,
+      'pathFilter': ?pathFilter,
     });
     return RequestEntriesResult.fromJson(result);
   }

--- a/lib/protocol/cast.dart
+++ b/lib/protocol/cast.dart
@@ -30,9 +30,7 @@ class CastApi {
   /// Also starts observing for issue messages. When an issue is added or removed,
   /// an |issueUpdated| event is fired.
   Future<void> enable({String? presentationUrl}) async {
-    await _client.send('Cast.enable', {
-      if (presentationUrl != null) 'presentationUrl': presentationUrl,
-    });
+    await _client.send('Cast.enable', {'presentationUrl': ?presentationUrl});
   }
 
   /// Stops observing for sinks and issues.

--- a/lib/protocol/css.dart
+++ b/lib/protocol/css.dart
@@ -79,8 +79,7 @@ class CSSApi {
       'styleSheetId': styleSheetId,
       'ruleText': ruleText,
       'location': location,
-      if (nodeForPropertySyntaxValidation != null)
-        'nodeForPropertySyntaxValidation': nodeForPropertySyntaxValidation,
+      'nodeForPropertySyntaxValidation': ?nodeForPropertySyntaxValidation,
     });
     return CSSRule.fromJson(result['rule'] as Map<String, dynamic>);
   }
@@ -107,7 +106,7 @@ class CSSApi {
   }) async {
     var result = await _client.send('CSS.createStyleSheet', {
       'frameId': frameId,
-      if (force != null) 'force': force,
+      'force': ?force,
     });
     return dom.StyleSheetId.fromJson(result['styleSheetId'] as String);
   }
@@ -194,9 +193,9 @@ class CSSApi {
     var result = await _client.send('CSS.resolveValues', {
       'values': [...values],
       'nodeId': nodeId,
-      if (propertyName != null) 'propertyName': propertyName,
-      if (pseudoType != null) 'pseudoType': pseudoType,
-      if (pseudoIdentifier != null) 'pseudoIdentifier': pseudoIdentifier,
+      'propertyName': ?propertyName,
+      'pseudoType': ?pseudoType,
+      'pseudoIdentifier': ?pseudoIdentifier,
     });
     return (result['results'] as List).map((e) => e as String).toList();
   }
@@ -315,7 +314,7 @@ class CSSApi {
   /// Pass `undefined` to disable tracking.
   Future<void> trackComputedStyleUpdatesForNode({dom.NodeId? nodeId}) async {
     await _client.send('CSS.trackComputedStyleUpdatesForNode', {
-      if (nodeId != null) 'nodeId': nodeId,
+      'nodeId': ?nodeId,
     });
   }
 
@@ -523,8 +522,7 @@ class CSSApi {
   }) async {
     var result = await _client.send('CSS.setStyleTexts', {
       'edits': [...edits],
-      if (nodeForPropertySyntaxValidation != null)
-        'nodeForPropertySyntaxValidation': nodeForPropertySyntaxValidation,
+      'nodeForPropertySyntaxValidation': ?nodeForPropertySyntaxValidation,
     });
     return (result['styles'] as List)
         .map((e) => CSSStyle.fromJson(e as Map<String, dynamic>))

--- a/lib/protocol/debugger.dart
+++ b/lib/protocol/debugger.dart
@@ -48,7 +48,7 @@ class DebuggerApi {
     );
     await _client.send('Debugger.continueToLocation', {
       'location': location,
-      if (targetCallFrames != null) 'targetCallFrames': targetCallFrames,
+      'targetCallFrames': ?targetCallFrames,
     });
   }
 
@@ -64,8 +64,7 @@ class DebuggerApi {
   /// Returns: Unique identifier of the debugger.
   Future<runtime.UniqueDebuggerId> enable({num? maxScriptsCacheSize}) async {
     var result = await _client.send('Debugger.enable', {
-      if (maxScriptsCacheSize != null)
-        'maxScriptsCacheSize': maxScriptsCacheSize,
+      'maxScriptsCacheSize': ?maxScriptsCacheSize,
     });
     return runtime.UniqueDebuggerId.fromJson(result['debuggerId'] as String);
   }
@@ -97,14 +96,13 @@ class DebuggerApi {
     var result = await _client.send('Debugger.evaluateOnCallFrame', {
       'callFrameId': callFrameId,
       'expression': expression,
-      if (objectGroup != null) 'objectGroup': objectGroup,
-      if (includeCommandLineAPI != null)
-        'includeCommandLineAPI': includeCommandLineAPI,
-      if (silent != null) 'silent': silent,
-      if (returnByValue != null) 'returnByValue': returnByValue,
-      if (generatePreview != null) 'generatePreview': generatePreview,
-      if (throwOnSideEffect != null) 'throwOnSideEffect': throwOnSideEffect,
-      if (timeout != null) 'timeout': timeout,
+      'objectGroup': ?objectGroup,
+      'includeCommandLineAPI': ?includeCommandLineAPI,
+      'silent': ?silent,
+      'returnByValue': ?returnByValue,
+      'generatePreview': ?generatePreview,
+      'throwOnSideEffect': ?throwOnSideEffect,
+      'timeout': ?timeout,
     });
     return EvaluateOnCallFrameResult.fromJson(result);
   }
@@ -123,8 +121,8 @@ class DebuggerApi {
   }) async {
     var result = await _client.send('Debugger.getPossibleBreakpoints', {
       'start': start,
-      if (end != null) 'end': end,
-      if (restrictToFunction != null) 'restrictToFunction': restrictToFunction,
+      'end': ?end,
+      'restrictToFunction': ?restrictToFunction,
     });
     return (result['locations'] as List)
         .map((e) => BreakLocation.fromJson(e as Map<String, dynamic>))
@@ -232,7 +230,7 @@ class DebuggerApi {
     assert(mode == null || const ['StepInto'].contains(mode));
     var result = await _client.send('Debugger.restartFrame', {
       'callFrameId': callFrameId,
-      if (mode != null) 'mode': mode,
+      'mode': ?mode,
     });
     return RestartFrameResult.fromJson(result);
   }
@@ -245,7 +243,7 @@ class DebuggerApi {
   /// If execution is currently not paused, this parameter has no effect.
   Future<void> resume({bool? terminateOnResume}) async {
     await _client.send('Debugger.resume', {
-      if (terminateOnResume != null) 'terminateOnResume': terminateOnResume,
+      'terminateOnResume': ?terminateOnResume,
     });
   }
 
@@ -264,8 +262,8 @@ class DebuggerApi {
     var result = await _client.send('Debugger.searchInContent', {
       'scriptId': scriptId,
       'query': query,
-      if (caseSensitive != null) 'caseSensitive': caseSensitive,
-      if (isRegex != null) 'isRegex': isRegex,
+      'caseSensitive': ?caseSensitive,
+      'isRegex': ?isRegex,
     });
     return (result['result'] as List)
         .map((e) => SearchMatch.fromJson(e as Map<String, dynamic>))
@@ -302,7 +300,7 @@ class DebuggerApi {
   }) async {
     await _client.send('Debugger.setBlackboxPatterns', {
       'patterns': [...patterns],
-      if (skipAnonymous != null) 'skipAnonymous': skipAnonymous,
+      'skipAnonymous': ?skipAnonymous,
     });
   }
 
@@ -331,7 +329,7 @@ class DebuggerApi {
   }) async {
     var result = await _client.send('Debugger.setBreakpoint', {
       'location': location,
-      if (condition != null) 'condition': condition,
+      'condition': ?condition,
     });
     return SetBreakpointResult.fromJson(result);
   }
@@ -377,11 +375,11 @@ class DebuggerApi {
   }) async {
     var result = await _client.send('Debugger.setBreakpointByUrl', {
       'lineNumber': lineNumber,
-      if (url != null) 'url': url,
-      if (urlRegex != null) 'urlRegex': urlRegex,
-      if (scriptHash != null) 'scriptHash': scriptHash,
-      if (columnNumber != null) 'columnNumber': columnNumber,
-      if (condition != null) 'condition': condition,
+      'url': ?url,
+      'urlRegex': ?urlRegex,
+      'scriptHash': ?scriptHash,
+      'columnNumber': ?columnNumber,
+      'condition': ?condition,
     });
     return SetBreakpointByUrlResult.fromJson(result);
   }
@@ -399,7 +397,7 @@ class DebuggerApi {
   }) async {
     var result = await _client.send('Debugger.setBreakpointOnFunctionCall', {
       'objectId': objectId,
-      if (condition != null) 'condition': condition,
+      'condition': ?condition,
     });
     return BreakpointId.fromJson(result['breakpointId'] as String);
   }
@@ -448,9 +446,8 @@ class DebuggerApi {
     var result = await _client.send('Debugger.setScriptSource', {
       'scriptId': scriptId,
       'scriptSource': scriptSource,
-      if (dryRun != null) 'dryRun': dryRun,
-      if (allowTopFrameEditing != null)
-        'allowTopFrameEditing': allowTopFrameEditing,
+      'dryRun': ?dryRun,
+      'allowTopFrameEditing': ?allowTopFrameEditing,
     });
     return SetScriptSourceResult.fromJson(result);
   }
@@ -491,7 +488,7 @@ class DebuggerApi {
     List<LocationRange>? skipList,
   }) async {
     await _client.send('Debugger.stepInto', {
-      if (breakOnAsyncCall != null) 'breakOnAsyncCall': breakOnAsyncCall,
+      'breakOnAsyncCall': ?breakOnAsyncCall,
       if (skipList != null) 'skipList': [...skipList],
     });
   }

--- a/lib/protocol/dom.dart
+++ b/lib/protocol/dom.dart
@@ -155,7 +155,7 @@ class DOMApi {
     var result = await _client.send('DOM.copyTo', {
       'nodeId': nodeId,
       'targetNodeId': targetNodeId,
-      if (insertBeforeNodeId != null) 'insertBeforeNodeId': insertBeforeNodeId,
+      'insertBeforeNodeId': ?insertBeforeNodeId,
     });
     return NodeId.fromJson(result['nodeId'] as int);
   }
@@ -178,11 +178,11 @@ class DOMApi {
     bool? pierce,
   }) async {
     var result = await _client.send('DOM.describeNode', {
-      if (nodeId != null) 'nodeId': nodeId,
-      if (backendNodeId != null) 'backendNodeId': backendNodeId,
-      if (objectId != null) 'objectId': objectId,
-      if (depth != null) 'depth': depth,
-      if (pierce != null) 'pierce': pierce,
+      'nodeId': ?nodeId,
+      'backendNodeId': ?backendNodeId,
+      'objectId': ?objectId,
+      'depth': ?depth,
+      'pierce': ?pierce,
     });
     return Node.fromJson(result['node'] as Map<String, dynamic>);
   }
@@ -202,10 +202,10 @@ class DOMApi {
     Rect? rect,
   }) async {
     await _client.send('DOM.scrollIntoViewIfNeeded', {
-      if (nodeId != null) 'nodeId': nodeId,
-      if (backendNodeId != null) 'backendNodeId': backendNodeId,
-      if (objectId != null) 'objectId': objectId,
-      if (rect != null) 'rect': rect,
+      'nodeId': ?nodeId,
+      'backendNodeId': ?backendNodeId,
+      'objectId': ?objectId,
+      'rect': ?rect,
     });
   }
 
@@ -230,9 +230,7 @@ class DOMApi {
       includeWhitespace == null ||
           const ['none', 'all'].contains(includeWhitespace),
     );
-    await _client.send('DOM.enable', {
-      if (includeWhitespace != null) 'includeWhitespace': includeWhitespace,
-    });
+    await _client.send('DOM.enable', {'includeWhitespace': ?includeWhitespace});
   }
 
   /// Focuses the given element.
@@ -245,9 +243,9 @@ class DOMApi {
     runtime.RemoteObjectId? objectId,
   }) async {
     await _client.send('DOM.focus', {
-      if (nodeId != null) 'nodeId': nodeId,
-      if (backendNodeId != null) 'backendNodeId': backendNodeId,
-      if (objectId != null) 'objectId': objectId,
+      'nodeId': ?nodeId,
+      'backendNodeId': ?backendNodeId,
+      'objectId': ?objectId,
     });
   }
 
@@ -270,9 +268,9 @@ class DOMApi {
     runtime.RemoteObjectId? objectId,
   }) async {
     var result = await _client.send('DOM.getBoxModel', {
-      if (nodeId != null) 'nodeId': nodeId,
-      if (backendNodeId != null) 'backendNodeId': backendNodeId,
-      if (objectId != null) 'objectId': objectId,
+      'nodeId': ?nodeId,
+      'backendNodeId': ?backendNodeId,
+      'objectId': ?objectId,
     });
     return BoxModel.fromJson(result['model'] as Map<String, dynamic>);
   }
@@ -289,9 +287,9 @@ class DOMApi {
     runtime.RemoteObjectId? objectId,
   }) async {
     var result = await _client.send('DOM.getContentQuads', {
-      if (nodeId != null) 'nodeId': nodeId,
-      if (backendNodeId != null) 'backendNodeId': backendNodeId,
-      if (objectId != null) 'objectId': objectId,
+      'nodeId': ?nodeId,
+      'backendNodeId': ?backendNodeId,
+      'objectId': ?objectId,
     });
     return (result['quads'] as List)
         .map((e) => Quad.fromJson(e as List))
@@ -307,8 +305,8 @@ class DOMApi {
   /// Returns: Resulting node.
   Future<Node> getDocument({int? depth, bool? pierce}) async {
     var result = await _client.send('DOM.getDocument', {
-      if (depth != null) 'depth': depth,
-      if (pierce != null) 'pierce': pierce,
+      'depth': ?depth,
+      'pierce': ?pierce,
     });
     return Node.fromJson(result['root'] as Map<String, dynamic>);
   }
@@ -324,8 +322,8 @@ class DOMApi {
   @Deprecated('Use DOMSnapshot.captureSnapshot instead')
   Future<List<Node>> getFlattenedDocument({int? depth, bool? pierce}) async {
     var result = await _client.send('DOM.getFlattenedDocument', {
-      if (depth != null) 'depth': depth,
-      if (pierce != null) 'pierce': pierce,
+      'depth': ?depth,
+      'pierce': ?pierce,
     });
     return (result['nodes'] as List)
         .map((e) => Node.fromJson(e as Map<String, dynamic>))
@@ -346,7 +344,7 @@ class DOMApi {
     var result = await _client.send('DOM.getNodesForSubtreeByStyle', {
       'nodeId': nodeId,
       'computedStyles': [...computedStyles],
-      if (pierce != null) 'pierce': pierce,
+      'pierce': ?pierce,
     });
     return (result['nodeIds'] as List)
         .map((e) => NodeId.fromJson(e as int))
@@ -368,10 +366,8 @@ class DOMApi {
     var result = await _client.send('DOM.getNodeForLocation', {
       'x': x,
       'y': y,
-      if (includeUserAgentShadowDOM != null)
-        'includeUserAgentShadowDOM': includeUserAgentShadowDOM,
-      if (ignorePointerEventsNone != null)
-        'ignorePointerEventsNone': ignorePointerEventsNone,
+      'includeUserAgentShadowDOM': ?includeUserAgentShadowDOM,
+      'ignorePointerEventsNone': ?ignorePointerEventsNone,
     });
     return GetNodeForLocationResult.fromJson(result);
   }
@@ -389,10 +385,10 @@ class DOMApi {
     bool? includeShadowDOM,
   }) async {
     var result = await _client.send('DOM.getOuterHTML', {
-      if (nodeId != null) 'nodeId': nodeId,
-      if (backendNodeId != null) 'backendNodeId': backendNodeId,
-      if (objectId != null) 'objectId': objectId,
-      if (includeShadowDOM != null) 'includeShadowDOM': includeShadowDOM,
+      'nodeId': ?nodeId,
+      'backendNodeId': ?backendNodeId,
+      'objectId': ?objectId,
+      'includeShadowDOM': ?includeShadowDOM,
     });
     return result['outerHTML'] as String;
   }
@@ -462,7 +458,7 @@ class DOMApi {
     var result = await _client.send('DOM.moveTo', {
       'nodeId': nodeId,
       'targetNodeId': targetNodeId,
-      if (insertBeforeNodeId != null) 'insertBeforeNodeId': insertBeforeNodeId,
+      'insertBeforeNodeId': ?insertBeforeNodeId,
     });
     return NodeId.fromJson(result['nodeId'] as int);
   }
@@ -477,8 +473,7 @@ class DOMApi {
   }) async {
     var result = await _client.send('DOM.performSearch', {
       'query': query,
-      if (includeUserAgentShadowDOM != null)
-        'includeUserAgentShadowDOM': includeUserAgentShadowDOM,
+      'includeUserAgentShadowDOM': ?includeUserAgentShadowDOM,
     });
     return PerformSearchResult.fromJson(result);
   }
@@ -600,8 +595,8 @@ class DOMApi {
   }) async {
     await _client.send('DOM.requestChildNodes', {
       'nodeId': nodeId,
-      if (depth != null) 'depth': depth,
-      if (pierce != null) 'pierce': pierce,
+      'depth': ?depth,
+      'pierce': ?pierce,
     });
   }
 
@@ -628,10 +623,10 @@ class DOMApi {
     runtime.ExecutionContextId? executionContextId,
   }) async {
     var result = await _client.send('DOM.resolveNode', {
-      if (nodeId != null) 'nodeId': nodeId,
-      if (backendNodeId != null) 'backendNodeId': backendNodeId,
-      if (objectGroup != null) 'objectGroup': objectGroup,
-      if (executionContextId != null) 'executionContextId': executionContextId,
+      'nodeId': ?nodeId,
+      'backendNodeId': ?backendNodeId,
+      'objectGroup': ?objectGroup,
+      'executionContextId': ?executionContextId,
     });
     return runtime.RemoteObject.fromJson(
       result['object'] as Map<String, dynamic>,
@@ -668,7 +663,7 @@ class DOMApi {
     await _client.send('DOM.setAttributesAsText', {
       'nodeId': nodeId,
       'text': text,
-      if (name != null) 'name': name,
+      'name': ?name,
     });
   }
 
@@ -685,9 +680,9 @@ class DOMApi {
   }) async {
     await _client.send('DOM.setFileInputFiles', {
       'files': [...files],
-      if (nodeId != null) 'nodeId': nodeId,
-      if (backendNodeId != null) 'backendNodeId': backendNodeId,
-      if (objectId != null) 'objectId': objectId,
+      'nodeId': ?nodeId,
+      'backendNodeId': ?backendNodeId,
+      'objectId': ?objectId,
     });
   }
 
@@ -789,11 +784,11 @@ class DOMApi {
   }) async {
     var result = await _client.send('DOM.getContainerForNode', {
       'nodeId': nodeId,
-      if (containerName != null) 'containerName': containerName,
-      if (physicalAxes != null) 'physicalAxes': physicalAxes,
-      if (logicalAxes != null) 'logicalAxes': logicalAxes,
-      if (queriesScrollState != null) 'queriesScrollState': queriesScrollState,
-      if (queriesAnchored != null) 'queriesAnchored': queriesAnchored,
+      'containerName': ?containerName,
+      'physicalAxes': ?physicalAxes,
+      'logicalAxes': ?logicalAxes,
+      'queriesScrollState': ?queriesScrollState,
+      'queriesAnchored': ?queriesAnchored,
     });
     return NodeId.fromJson(result['nodeId'] as int);
   }
@@ -825,7 +820,7 @@ class DOMApi {
   }) async {
     var result = await _client.send('DOM.getAnchorElement', {
       'nodeId': nodeId,
-      if (anchorSpecifier != null) 'anchorSpecifier': anchorSpecifier,
+      'anchorSpecifier': ?anchorSpecifier,
     });
     return NodeId.fromJson(result['nodeId'] as int);
   }
@@ -848,7 +843,7 @@ class DOMApi {
     var result = await _client.send('DOM.forceShowPopover', {
       'nodeId': nodeId,
       'enable': enable,
-      if (invokerNodeId != null) 'invokerNodeId': invokerNodeId,
+      'invokerNodeId': ?invokerNodeId,
     });
     return (result['nodeIds'] as List)
         .map((e) => NodeId.fromJson(e as int))

--- a/lib/protocol/dom_debugger.dart
+++ b/lib/protocol/dom_debugger.dart
@@ -24,8 +24,8 @@ class DOMDebuggerApi {
   }) async {
     var result = await _client.send('DOMDebugger.getEventListeners', {
       'objectId': objectId,
-      if (depth != null) 'depth': depth,
-      if (pierce != null) 'pierce': pierce,
+      'depth': ?depth,
+      'pierce': ?pierce,
     });
     return (result['listeners'] as List)
         .map((e) => EventListener.fromJson(e as Map<String, dynamic>))
@@ -54,7 +54,7 @@ class DOMDebuggerApi {
   }) async {
     await _client.send('DOMDebugger.removeEventListenerBreakpoint', {
       'eventName': eventName,
-      if (targetName != null) 'targetName': targetName,
+      'targetName': ?targetName,
     });
   }
 
@@ -106,7 +106,7 @@ class DOMDebuggerApi {
   }) async {
     await _client.send('DOMDebugger.setEventListenerBreakpoint', {
       'eventName': eventName,
-      if (targetName != null) 'targetName': targetName,
+      'targetName': ?targetName,
     });
   }
 

--- a/lib/protocol/dom_snapshot.dart
+++ b/lib/protocol/dom_snapshot.dart
@@ -37,11 +37,9 @@ class DOMSnapshotApi {
   }) async {
     var result = await _client.send('DOMSnapshot.getSnapshot', {
       'computedStyleWhitelist': [...computedStyleWhitelist],
-      if (includeEventListeners != null)
-        'includeEventListeners': includeEventListeners,
-      if (includePaintOrder != null) 'includePaintOrder': includePaintOrder,
-      if (includeUserAgentShadowTree != null)
-        'includeUserAgentShadowTree': includeUserAgentShadowTree,
+      'includeEventListeners': ?includeEventListeners,
+      'includePaintOrder': ?includePaintOrder,
+      'includeUserAgentShadowTree': ?includeUserAgentShadowTree,
     });
     return GetSnapshotResult.fromJson(result);
   }
@@ -68,12 +66,10 @@ class DOMSnapshotApi {
   }) async {
     var result = await _client.send('DOMSnapshot.captureSnapshot', {
       'computedStyles': [...computedStyles],
-      if (includePaintOrder != null) 'includePaintOrder': includePaintOrder,
-      if (includeDOMRects != null) 'includeDOMRects': includeDOMRects,
-      if (includeBlendedBackgroundColors != null)
-        'includeBlendedBackgroundColors': includeBlendedBackgroundColors,
-      if (includeTextColorOpacities != null)
-        'includeTextColorOpacities': includeTextColorOpacities,
+      'includePaintOrder': ?includePaintOrder,
+      'includeDOMRects': ?includeDOMRects,
+      'includeBlendedBackgroundColors': ?includeBlendedBackgroundColors,
+      'includeTextColorOpacities': ?includeTextColorOpacities,
     });
     return CaptureSnapshotResult.fromJson(result);
   }

--- a/lib/protocol/emulation.dart
+++ b/lib/protocol/emulation.dart
@@ -61,7 +61,7 @@ class EmulationApi {
   /// If not specified, any existing override will be cleared.
   Future<void> setAutoDarkModeOverride({bool? enabled}) async {
     await _client.send('Emulation.setAutoDarkModeOverride', {
-      if (enabled != null) 'enabled': enabled,
+      'enabled': ?enabled,
     });
   }
 
@@ -77,7 +77,7 @@ class EmulationApi {
   /// cleared.
   Future<void> setDefaultBackgroundColorOverride({dom.RGBA? color}) async {
     await _client.send('Emulation.setDefaultBackgroundColorOverride', {
-      if (color != null) 'color': color,
+      'color': ?color,
     });
   }
 
@@ -141,19 +141,18 @@ class EmulationApi {
       'height': height,
       'deviceScaleFactor': deviceScaleFactor,
       'mobile': mobile,
-      if (scale != null) 'scale': scale,
-      if (screenWidth != null) 'screenWidth': screenWidth,
-      if (screenHeight != null) 'screenHeight': screenHeight,
-      if (positionX != null) 'positionX': positionX,
-      if (positionY != null) 'positionY': positionY,
-      if (dontSetVisibleSize != null) 'dontSetVisibleSize': dontSetVisibleSize,
-      if (screenOrientation != null) 'screenOrientation': screenOrientation,
-      if (viewport != null) 'viewport': viewport,
-      if (displayFeature != null) 'displayFeature': displayFeature,
-      if (devicePosture != null) 'devicePosture': devicePosture,
-      if (scrollbarType != null) 'scrollbarType': scrollbarType,
-      if (screenOrientationLockEmulation != null)
-        'screenOrientationLockEmulation': screenOrientationLockEmulation,
+      'scale': ?scale,
+      'screenWidth': ?screenWidth,
+      'screenHeight': ?screenHeight,
+      'positionX': ?positionX,
+      'positionY': ?positionY,
+      'dontSetVisibleSize': ?dontSetVisibleSize,
+      'screenOrientation': ?screenOrientation,
+      'viewport': ?viewport,
+      'displayFeature': ?displayFeature,
+      'devicePosture': ?devicePosture,
+      'scrollbarType': ?scrollbarType,
+      'screenOrientationLockEmulation': ?screenOrientationLockEmulation,
     });
   }
 
@@ -213,7 +212,7 @@ class EmulationApi {
     );
     await _client.send('Emulation.setEmitTouchEventsForMouse', {
       'enabled': enabled,
-      if (configuration != null) 'configuration': configuration,
+      'configuration': ?configuration,
     });
   }
 
@@ -225,7 +224,7 @@ class EmulationApi {
     List<MediaFeature>? features,
   }) async {
     await _client.send('Emulation.setEmulatedMedia', {
-      if (media != null) 'media': media,
+      'media': ?media,
       if (features != null) 'features': [...features],
     });
   }
@@ -261,9 +260,7 @@ class EmulationApi {
 
   /// Emulates the given OS text scale.
   Future<void> setEmulatedOSTextScale({num? scale}) async {
-    await _client.send('Emulation.setEmulatedOSTextScale', {
-      if (scale != null) 'scale': scale,
-    });
+    await _client.send('Emulation.setEmulatedOSTextScale', {'scale': ?scale});
   }
 
   /// Overrides the Geolocation Position or Error. Omitting latitude, longitude or
@@ -285,13 +282,13 @@ class EmulationApi {
     num? speed,
   }) async {
     await _client.send('Emulation.setGeolocationOverride', {
-      if (latitude != null) 'latitude': latitude,
-      if (longitude != null) 'longitude': longitude,
-      if (accuracy != null) 'accuracy': accuracy,
-      if (altitude != null) 'altitude': altitude,
-      if (altitudeAccuracy != null) 'altitudeAccuracy': altitudeAccuracy,
-      if (heading != null) 'heading': heading,
-      if (speed != null) 'speed': speed,
+      'latitude': ?latitude,
+      'longitude': ?longitude,
+      'accuracy': ?accuracy,
+      'altitude': ?altitude,
+      'altitudeAccuracy': ?altitudeAccuracy,
+      'heading': ?heading,
+      'speed': ?speed,
     });
   }
 
@@ -316,7 +313,7 @@ class EmulationApi {
     await _client.send('Emulation.setSensorOverrideEnabled', {
       'enabled': enabled,
       'type': type,
-      if (metadata != null) 'metadata': metadata,
+      'metadata': ?metadata,
     });
   }
 
@@ -344,7 +341,7 @@ class EmulationApi {
     await _client.send('Emulation.setPressureSourceOverrideEnabled', {
       'enabled': enabled,
       'source': source,
-      if (metadata != null) 'metadata': metadata,
+      'metadata': ?metadata,
     });
   }
 
@@ -410,7 +407,7 @@ class EmulationApi {
   }) async {
     await _client.send('Emulation.setTouchEmulationEnabled', {
       'enabled': enabled,
-      if (maxTouchPoints != null) 'maxTouchPoints': maxTouchPoints,
+      'maxTouchPoints': ?maxTouchPoints,
     });
   }
 
@@ -430,10 +427,9 @@ class EmulationApi {
   }) async {
     var result = await _client.send('Emulation.setVirtualTimePolicy', {
       'policy': policy,
-      if (budget != null) 'budget': budget,
-      if (maxVirtualTimeTaskStarvationCount != null)
-        'maxVirtualTimeTaskStarvationCount': maxVirtualTimeTaskStarvationCount,
-      if (initialVirtualTime != null) 'initialVirtualTime': initialVirtualTime,
+      'budget': ?budget,
+      'maxVirtualTimeTaskStarvationCount': ?maxVirtualTimeTaskStarvationCount,
+      'initialVirtualTime': ?initialVirtualTime,
     });
     return result['virtualTimeTicksBase'] as num;
   }
@@ -442,9 +438,7 @@ class EmulationApi {
   /// [locale] ICU style C locale (e.g. "en_US"). If not specified or empty, disables the override and
   /// restores default host system locale.
   Future<void> setLocaleOverride({String? locale}) async {
-    await _client.send('Emulation.setLocaleOverride', {
-      if (locale != null) 'locale': locale,
-    });
+    await _client.send('Emulation.setLocaleOverride', {'locale': ?locale});
   }
 
   /// Overrides default host system timezone with the specified one.
@@ -481,7 +475,7 @@ class EmulationApi {
   /// [dataSaverEnabled] Override value. Omitting the parameter disables the override.
   Future<void> setDataSaverOverride({bool? dataSaverEnabled}) async {
     await _client.send('Emulation.setDataSaverOverride', {
-      if (dataSaverEnabled != null) 'dataSaverEnabled': dataSaverEnabled,
+      'dataSaverEnabled': ?dataSaverEnabled,
     });
   }
 
@@ -506,9 +500,9 @@ class EmulationApi {
   }) async {
     await _client.send('Emulation.setUserAgentOverride', {
       'userAgent': userAgent,
-      if (acceptLanguage != null) 'acceptLanguage': acceptLanguage,
-      if (platform != null) 'platform': platform,
-      if (userAgentMetadata != null) 'userAgentMetadata': userAgentMetadata,
+      'acceptLanguage': ?acceptLanguage,
+      'platform': ?platform,
+      'userAgentMetadata': ?userAgentMetadata,
     });
   }
 
@@ -565,12 +559,12 @@ class EmulationApi {
       'top': top,
       'width': width,
       'height': height,
-      if (workAreaInsets != null) 'workAreaInsets': workAreaInsets,
-      if (devicePixelRatio != null) 'devicePixelRatio': devicePixelRatio,
-      if (rotation != null) 'rotation': rotation,
-      if (colorDepth != null) 'colorDepth': colorDepth,
-      if (label != null) 'label': label,
-      if (isInternal != null) 'isInternal': isInternal,
+      'workAreaInsets': ?workAreaInsets,
+      'devicePixelRatio': ?devicePixelRatio,
+      'rotation': ?rotation,
+      'colorDepth': ?colorDepth,
+      'label': ?label,
+      'isInternal': ?isInternal,
     });
     return ScreenInfo.fromJson(result['screenInfo'] as Map<String, dynamic>);
   }
@@ -602,16 +596,16 @@ class EmulationApi {
   }) async {
     var result = await _client.send('Emulation.updateScreen', {
       'screenId': screenId,
-      if (left != null) 'left': left,
-      if (top != null) 'top': top,
-      if (width != null) 'width': width,
-      if (height != null) 'height': height,
-      if (workAreaInsets != null) 'workAreaInsets': workAreaInsets,
-      if (devicePixelRatio != null) 'devicePixelRatio': devicePixelRatio,
-      if (rotation != null) 'rotation': rotation,
-      if (colorDepth != null) 'colorDepth': colorDepth,
-      if (label != null) 'label': label,
-      if (isInternal != null) 'isInternal': isInternal,
+      'left': ?left,
+      'top': ?top,
+      'width': ?width,
+      'height': ?height,
+      'workAreaInsets': ?workAreaInsets,
+      'devicePixelRatio': ?devicePixelRatio,
+      'rotation': ?rotation,
+      'colorDepth': ?colorDepth,
+      'label': ?label,
+      'isInternal': ?isInternal,
     });
     return ScreenInfo.fromJson(result['screenInfo'] as Map<String, dynamic>);
   }

--- a/lib/protocol/extensions.dart
+++ b/lib/protocol/extensions.dart
@@ -26,7 +26,7 @@ class ExtensionsApi {
   Future<String> loadUnpacked(String path, {bool? enableInIncognito}) async {
     var result = await _client.send('Extensions.loadUnpacked', {
       'path': path,
-      if (enableInIncognito != null) 'enableInIncognito': enableInIncognito,
+      'enableInIncognito': ?enableInIncognito,
     });
     return result['id'] as String;
   }

--- a/lib/protocol/fed_cm.dart
+++ b/lib/protocol/fed_cm.dart
@@ -22,8 +22,7 @@ class FedCmApi {
   /// (step 4 of https://fedidcg.github.io/FedCM/#browser-api-rp-sign-in)
   Future<void> enable({bool? disableRejectionDelay}) async {
     await _client.send('FedCm.enable', {
-      if (disableRejectionDelay != null)
-        'disableRejectionDelay': disableRejectionDelay,
+      'disableRejectionDelay': ?disableRejectionDelay,
     });
   }
 
@@ -63,7 +62,7 @@ class FedCmApi {
   Future<void> dismissDialog(String dialogId, {bool? triggerCooldown}) async {
     await _client.send('FedCm.dismissDialog', {
       'dialogId': dialogId,
-      if (triggerCooldown != null) 'triggerCooldown': triggerCooldown,
+      'triggerCooldown': ?triggerCooldown,
     });
   }
 

--- a/lib/protocol/fetch.dart
+++ b/lib/protocol/fetch.dart
@@ -49,7 +49,7 @@ class FetchApi {
   }) async {
     await _client.send('Fetch.enable', {
       if (patterns != null) 'patterns': [...patterns],
-      if (handleAuthRequests != null) 'handleAuthRequests': handleAuthRequests,
+      'handleAuthRequests': ?handleAuthRequests,
     });
   }
 
@@ -91,10 +91,9 @@ class FetchApi {
       'requestId': requestId,
       'responseCode': responseCode,
       if (responseHeaders != null) 'responseHeaders': [...responseHeaders],
-      if (binaryResponseHeaders != null)
-        'binaryResponseHeaders': binaryResponseHeaders,
-      if (body != null) 'body': body,
-      if (responsePhrase != null) 'responsePhrase': responsePhrase,
+      'binaryResponseHeaders': ?binaryResponseHeaders,
+      'body': ?body,
+      'responsePhrase': ?responsePhrase,
     });
   }
 
@@ -117,11 +116,11 @@ class FetchApi {
   }) async {
     await _client.send('Fetch.continueRequest', {
       'requestId': requestId,
-      if (url != null) 'url': url,
-      if (method != null) 'method': method,
-      if (postData != null) 'postData': postData,
+      'url': ?url,
+      'method': ?method,
+      'postData': ?postData,
       if (headers != null) 'headers': [...headers],
-      if (interceptResponse != null) 'interceptResponse': interceptResponse,
+      'interceptResponse': ?interceptResponse,
     });
   }
 
@@ -159,11 +158,10 @@ class FetchApi {
   }) async {
     await _client.send('Fetch.continueResponse', {
       'requestId': requestId,
-      if (responseCode != null) 'responseCode': responseCode,
-      if (responsePhrase != null) 'responsePhrase': responsePhrase,
+      'responseCode': ?responseCode,
+      'responsePhrase': ?responsePhrase,
       if (responseHeaders != null) 'responseHeaders': [...responseHeaders],
-      if (binaryResponseHeaders != null)
-        'binaryResponseHeaders': binaryResponseHeaders,
+      'binaryResponseHeaders': ?binaryResponseHeaders,
     });
   }
 

--- a/lib/protocol/headless_experimental.dart
+++ b/lib/protocol/headless_experimental.dart
@@ -28,10 +28,10 @@ class HeadlessExperimentalApi {
     ScreenshotParams? screenshot,
   }) async {
     var result = await _client.send('HeadlessExperimental.beginFrame', {
-      if (frameTimeTicks != null) 'frameTimeTicks': frameTimeTicks,
-      if (interval != null) 'interval': interval,
-      if (noDisplayUpdates != null) 'noDisplayUpdates': noDisplayUpdates,
-      if (screenshot != null) 'screenshot': screenshot,
+      'frameTimeTicks': ?frameTimeTicks,
+      'interval': ?interval,
+      'noDisplayUpdates': ?noDisplayUpdates,
+      'screenshot': ?screenshot,
     });
     return BeginFrameResult.fromJson(result);
   }

--- a/lib/protocol/heap_profiler.dart
+++ b/lib/protocol/heap_profiler.dart
@@ -83,7 +83,7 @@ class HeapProfilerApi {
   }) async {
     var result = await _client.send('HeapProfiler.getObjectByHeapObjectId', {
       'objectId': objectId,
-      if (objectGroup != null) 'objectGroup': objectGroup,
+      'objectGroup': ?objectGroup,
     });
     return runtime.RemoteObject.fromJson(
       result['result'] as Map<String, dynamic>,
@@ -122,18 +122,16 @@ class HeapProfilerApi {
     bool? includeObjectsCollectedByMinorGC,
   }) async {
     await _client.send('HeapProfiler.startSampling', {
-      if (samplingInterval != null) 'samplingInterval': samplingInterval,
-      if (stackDepth != null) 'stackDepth': stackDepth,
-      if (includeObjectsCollectedByMajorGC != null)
-        'includeObjectsCollectedByMajorGC': includeObjectsCollectedByMajorGC,
-      if (includeObjectsCollectedByMinorGC != null)
-        'includeObjectsCollectedByMinorGC': includeObjectsCollectedByMinorGC,
+      'samplingInterval': ?samplingInterval,
+      'stackDepth': ?stackDepth,
+      'includeObjectsCollectedByMajorGC': ?includeObjectsCollectedByMajorGC,
+      'includeObjectsCollectedByMinorGC': ?includeObjectsCollectedByMinorGC,
     });
   }
 
   Future<void> startTrackingHeapObjects({bool? trackAllocations}) async {
     await _client.send('HeapProfiler.startTrackingHeapObjects', {
-      if (trackAllocations != null) 'trackAllocations': trackAllocations,
+      'trackAllocations': ?trackAllocations,
     });
   }
 
@@ -156,12 +154,10 @@ class HeapProfilerApi {
     bool? exposeInternals,
   }) async {
     await _client.send('HeapProfiler.stopTrackingHeapObjects', {
-      if (reportProgress != null) 'reportProgress': reportProgress,
-      if (treatGlobalObjectsAsRoots != null)
-        'treatGlobalObjectsAsRoots': treatGlobalObjectsAsRoots,
-      if (captureNumericValue != null)
-        'captureNumericValue': captureNumericValue,
-      if (exposeInternals != null) 'exposeInternals': exposeInternals,
+      'reportProgress': ?reportProgress,
+      'treatGlobalObjectsAsRoots': ?treatGlobalObjectsAsRoots,
+      'captureNumericValue': ?captureNumericValue,
+      'exposeInternals': ?exposeInternals,
     });
   }
 
@@ -175,12 +171,10 @@ class HeapProfilerApi {
     bool? exposeInternals,
   }) async {
     await _client.send('HeapProfiler.takeHeapSnapshot', {
-      if (reportProgress != null) 'reportProgress': reportProgress,
-      if (treatGlobalObjectsAsRoots != null)
-        'treatGlobalObjectsAsRoots': treatGlobalObjectsAsRoots,
-      if (captureNumericValue != null)
-        'captureNumericValue': captureNumericValue,
-      if (exposeInternals != null) 'exposeInternals': exposeInternals,
+      'reportProgress': ?reportProgress,
+      'treatGlobalObjectsAsRoots': ?treatGlobalObjectsAsRoots,
+      'captureNumericValue': ?captureNumericValue,
+      'exposeInternals': ?exposeInternals,
     });
   }
 }

--- a/lib/protocol/indexed_db.dart
+++ b/lib/protocol/indexed_db.dart
@@ -25,9 +25,9 @@ class IndexedDBApi {
     await _client.send('IndexedDB.clearObjectStore', {
       'databaseName': databaseName,
       'objectStoreName': objectStoreName,
-      if (securityOrigin != null) 'securityOrigin': securityOrigin,
-      if (storageKey != null) 'storageKey': storageKey,
-      if (storageBucket != null) 'storageBucket': storageBucket,
+      'securityOrigin': ?securityOrigin,
+      'storageKey': ?storageKey,
+      'storageBucket': ?storageBucket,
     });
   }
 
@@ -45,9 +45,9 @@ class IndexedDBApi {
   }) async {
     await _client.send('IndexedDB.deleteDatabase', {
       'databaseName': databaseName,
-      if (securityOrigin != null) 'securityOrigin': securityOrigin,
-      if (storageKey != null) 'storageKey': storageKey,
-      if (storageBucket != null) 'storageBucket': storageBucket,
+      'securityOrigin': ?securityOrigin,
+      'storageKey': ?storageKey,
+      'storageBucket': ?storageBucket,
     });
   }
 
@@ -69,9 +69,9 @@ class IndexedDBApi {
       'databaseName': databaseName,
       'objectStoreName': objectStoreName,
       'keyRange': keyRange,
-      if (securityOrigin != null) 'securityOrigin': securityOrigin,
-      if (storageKey != null) 'storageKey': storageKey,
-      if (storageBucket != null) 'storageBucket': storageBucket,
+      'securityOrigin': ?securityOrigin,
+      'storageKey': ?storageKey,
+      'storageBucket': ?storageBucket,
     });
   }
 
@@ -112,11 +112,11 @@ class IndexedDBApi {
       'objectStoreName': objectStoreName,
       'skipCount': skipCount,
       'pageSize': pageSize,
-      if (securityOrigin != null) 'securityOrigin': securityOrigin,
-      if (storageKey != null) 'storageKey': storageKey,
-      if (storageBucket != null) 'storageBucket': storageBucket,
-      if (indexName != null) 'indexName': indexName,
-      if (keyRange != null) 'keyRange': keyRange,
+      'securityOrigin': ?securityOrigin,
+      'storageKey': ?storageKey,
+      'storageBucket': ?storageBucket,
+      'indexName': ?indexName,
+      'keyRange': ?keyRange,
     });
     return RequestDataResult.fromJson(result);
   }
@@ -138,9 +138,9 @@ class IndexedDBApi {
     var result = await _client.send('IndexedDB.getMetadata', {
       'databaseName': databaseName,
       'objectStoreName': objectStoreName,
-      if (securityOrigin != null) 'securityOrigin': securityOrigin,
-      if (storageKey != null) 'storageKey': storageKey,
-      if (storageBucket != null) 'storageBucket': storageBucket,
+      'securityOrigin': ?securityOrigin,
+      'storageKey': ?storageKey,
+      'storageBucket': ?storageBucket,
     });
     return GetMetadataResult.fromJson(result);
   }
@@ -160,9 +160,9 @@ class IndexedDBApi {
   }) async {
     var result = await _client.send('IndexedDB.requestDatabase', {
       'databaseName': databaseName,
-      if (securityOrigin != null) 'securityOrigin': securityOrigin,
-      if (storageKey != null) 'storageKey': storageKey,
-      if (storageBucket != null) 'storageBucket': storageBucket,
+      'securityOrigin': ?securityOrigin,
+      'storageKey': ?storageKey,
+      'storageBucket': ?storageBucket,
     });
     return DatabaseWithObjectStores.fromJson(
       result['databaseWithObjectStores'] as Map<String, dynamic>,
@@ -181,9 +181,9 @@ class IndexedDBApi {
     storage.StorageBucket? storageBucket,
   }) async {
     var result = await _client.send('IndexedDB.requestDatabaseNames', {
-      if (securityOrigin != null) 'securityOrigin': securityOrigin,
-      if (storageKey != null) 'storageKey': storageKey,
-      if (storageBucket != null) 'storageBucket': storageBucket,
+      'securityOrigin': ?securityOrigin,
+      'storageKey': ?storageKey,
+      'storageBucket': ?storageBucket,
     });
     return (result['databaseNames'] as List).map((e) => e as String).toList();
   }

--- a/lib/protocol/input.dart
+++ b/lib/protocol/input.dart
@@ -37,7 +37,7 @@ class InputApi {
       'x': x,
       'y': y,
       'data': data,
-      if (modifiers != null) 'modifiers': modifiers,
+      'modifiers': ?modifiers,
     });
   }
 
@@ -84,21 +84,19 @@ class InputApi {
     assert(const ['keyDown', 'keyUp', 'rawKeyDown', 'char'].contains(type));
     await _client.send('Input.dispatchKeyEvent', {
       'type': type,
-      if (modifiers != null) 'modifiers': modifiers,
-      if (timestamp != null) 'timestamp': timestamp,
-      if (text != null) 'text': text,
-      if (unmodifiedText != null) 'unmodifiedText': unmodifiedText,
-      if (keyIdentifier != null) 'keyIdentifier': keyIdentifier,
-      if (code != null) 'code': code,
-      if (key != null) 'key': key,
-      if (windowsVirtualKeyCode != null)
-        'windowsVirtualKeyCode': windowsVirtualKeyCode,
-      if (nativeVirtualKeyCode != null)
-        'nativeVirtualKeyCode': nativeVirtualKeyCode,
-      if (autoRepeat != null) 'autoRepeat': autoRepeat,
-      if (isKeypad != null) 'isKeypad': isKeypad,
-      if (isSystemKey != null) 'isSystemKey': isSystemKey,
-      if (location != null) 'location': location,
+      'modifiers': ?modifiers,
+      'timestamp': ?timestamp,
+      'text': ?text,
+      'unmodifiedText': ?unmodifiedText,
+      'keyIdentifier': ?keyIdentifier,
+      'code': ?code,
+      'key': ?key,
+      'windowsVirtualKeyCode': ?windowsVirtualKeyCode,
+      'nativeVirtualKeyCode': ?nativeVirtualKeyCode,
+      'autoRepeat': ?autoRepeat,
+      'isKeypad': ?isKeypad,
+      'isSystemKey': ?isSystemKey,
+      'location': ?location,
       if (commands != null) 'commands': [...commands],
     });
   }
@@ -129,8 +127,8 @@ class InputApi {
       'text': text,
       'selectionStart': selectionStart,
       'selectionEnd': selectionEnd,
-      if (replacementStart != null) 'replacementStart': replacementStart,
-      if (replacementEnd != null) 'replacementEnd': replacementEnd,
+      'replacementStart': ?replacementStart,
+      'replacementEnd': ?replacementEnd,
     });
   }
 
@@ -186,19 +184,19 @@ class InputApi {
       'type': type,
       'x': x,
       'y': y,
-      if (modifiers != null) 'modifiers': modifiers,
-      if (timestamp != null) 'timestamp': timestamp,
-      if (button != null) 'button': button,
-      if (buttons != null) 'buttons': buttons,
-      if (clickCount != null) 'clickCount': clickCount,
-      if (force != null) 'force': force,
-      if (tangentialPressure != null) 'tangentialPressure': tangentialPressure,
-      if (tiltX != null) 'tiltX': tiltX,
-      if (tiltY != null) 'tiltY': tiltY,
-      if (twist != null) 'twist': twist,
-      if (deltaX != null) 'deltaX': deltaX,
-      if (deltaY != null) 'deltaY': deltaY,
-      if (pointerType != null) 'pointerType': pointerType,
+      'modifiers': ?modifiers,
+      'timestamp': ?timestamp,
+      'button': ?button,
+      'buttons': ?buttons,
+      'clickCount': ?clickCount,
+      'force': ?force,
+      'tangentialPressure': ?tangentialPressure,
+      'tiltX': ?tiltX,
+      'tiltY': ?tiltY,
+      'twist': ?twist,
+      'deltaX': ?deltaX,
+      'deltaY': ?deltaY,
+      'pointerType': ?pointerType,
     });
   }
 
@@ -228,8 +226,8 @@ class InputApi {
     await _client.send('Input.dispatchTouchEvent', {
       'type': type,
       'touchPoints': [...touchPoints],
-      if (modifiers != null) 'modifiers': modifiers,
-      if (timestamp != null) 'timestamp': timestamp,
+      'modifiers': ?modifiers,
+      'timestamp': ?timestamp,
     });
   }
 
@@ -274,11 +272,11 @@ class InputApi {
       'x': x,
       'y': y,
       'button': button,
-      if (timestamp != null) 'timestamp': timestamp,
-      if (deltaX != null) 'deltaX': deltaX,
-      if (deltaY != null) 'deltaY': deltaY,
-      if (modifiers != null) 'modifiers': modifiers,
-      if (clickCount != null) 'clickCount': clickCount,
+      'timestamp': ?timestamp,
+      'deltaX': ?deltaX,
+      'deltaY': ?deltaY,
+      'modifiers': ?modifiers,
+      'clickCount': ?clickCount,
     });
   }
 
@@ -312,8 +310,8 @@ class InputApi {
       'x': x,
       'y': y,
       'scaleFactor': scaleFactor,
-      if (relativeSpeed != null) 'relativeSpeed': relativeSpeed,
-      if (gestureSourceType != null) 'gestureSourceType': gestureSourceType,
+      'relativeSpeed': ?relativeSpeed,
+      'gestureSourceType': ?gestureSourceType,
     });
   }
 
@@ -350,17 +348,16 @@ class InputApi {
     await _client.send('Input.synthesizeScrollGesture', {
       'x': x,
       'y': y,
-      if (xDistance != null) 'xDistance': xDistance,
-      if (yDistance != null) 'yDistance': yDistance,
-      if (xOverscroll != null) 'xOverscroll': xOverscroll,
-      if (yOverscroll != null) 'yOverscroll': yOverscroll,
-      if (preventFling != null) 'preventFling': preventFling,
-      if (speed != null) 'speed': speed,
-      if (gestureSourceType != null) 'gestureSourceType': gestureSourceType,
-      if (repeatCount != null) 'repeatCount': repeatCount,
-      if (repeatDelayMs != null) 'repeatDelayMs': repeatDelayMs,
-      if (interactionMarkerName != null)
-        'interactionMarkerName': interactionMarkerName,
+      'xDistance': ?xDistance,
+      'yDistance': ?yDistance,
+      'xOverscroll': ?xOverscroll,
+      'yOverscroll': ?yOverscroll,
+      'preventFling': ?preventFling,
+      'speed': ?speed,
+      'gestureSourceType': ?gestureSourceType,
+      'repeatCount': ?repeatCount,
+      'repeatDelayMs': ?repeatDelayMs,
+      'interactionMarkerName': ?interactionMarkerName,
     });
   }
 
@@ -381,9 +378,9 @@ class InputApi {
     await _client.send('Input.synthesizeTapGesture', {
       'x': x,
       'y': y,
-      if (duration != null) 'duration': duration,
-      if (tapCount != null) 'tapCount': tapCount,
-      if (gestureSourceType != null) 'gestureSourceType': gestureSourceType,
+      'duration': ?duration,
+      'tapCount': ?tapCount,
+      'gestureSourceType': ?gestureSourceType,
     });
   }
 }

--- a/lib/protocol/io.dart
+++ b/lib/protocol/io.dart
@@ -22,8 +22,8 @@ class IOApi {
   Future<ReadResult> read(StreamHandle handle, {int? offset, int? size}) async {
     var result = await _client.send('IO.read', {
       'handle': handle,
-      if (offset != null) 'offset': offset,
-      if (size != null) 'size': size,
+      'offset': ?offset,
+      'size': ?size,
     });
     return ReadResult.fromJson(result);
   }

--- a/lib/protocol/layer_tree.dart
+++ b/lib/protocol/layer_tree.dart
@@ -71,9 +71,9 @@ class LayerTreeApi {
   }) async {
     var result = await _client.send('LayerTree.profileSnapshot', {
       'snapshotId': snapshotId,
-      if (minRepeatCount != null) 'minRepeatCount': minRepeatCount,
-      if (minDuration != null) 'minDuration': minDuration,
-      if (clipRect != null) 'clipRect': clipRect,
+      'minRepeatCount': ?minRepeatCount,
+      'minDuration': ?minDuration,
+      'clipRect': ?clipRect,
     });
     return (result['timings'] as List)
         .map((e) => PaintProfile.fromJson(e as List))
@@ -100,9 +100,9 @@ class LayerTreeApi {
   }) async {
     var result = await _client.send('LayerTree.replaySnapshot', {
       'snapshotId': snapshotId,
-      if (fromStep != null) 'fromStep': fromStep,
-      if (toStep != null) 'toStep': toStep,
-      if (scale != null) 'scale': scale,
+      'fromStep': ?fromStep,
+      'toStep': ?toStep,
+      'scale': ?scale,
     });
     return result['dataURL'] as String;
   }

--- a/lib/protocol/memory.dart
+++ b/lib/protocol/memory.dart
@@ -54,8 +54,8 @@ class MemoryApi {
     bool? suppressRandomness,
   }) async {
     await _client.send('Memory.startSampling', {
-      if (samplingInterval != null) 'samplingInterval': samplingInterval,
-      if (suppressRandomness != null) 'suppressRandomness': suppressRandomness,
+      'samplingInterval': ?samplingInterval,
+      'suppressRandomness': ?suppressRandomness,
     });
   }
 

--- a/lib/protocol/network.dart
+++ b/lib/protocol/network.dart
@@ -420,14 +420,13 @@ class NetworkApi {
   }) async {
     await _client.send('Network.continueInterceptedRequest', {
       'interceptionId': interceptionId,
-      if (errorReason != null) 'errorReason': errorReason,
-      if (rawResponse != null) 'rawResponse': rawResponse,
-      if (url != null) 'url': url,
-      if (method != null) 'method': method,
-      if (postData != null) 'postData': postData,
-      if (headers != null) 'headers': headers,
-      if (authChallengeResponse != null)
-        'authChallengeResponse': authChallengeResponse,
+      'errorReason': ?errorReason,
+      'rawResponse': ?rawResponse,
+      'url': ?url,
+      'method': ?method,
+      'postData': ?postData,
+      'headers': ?headers,
+      'authChallengeResponse': ?authChallengeResponse,
     });
   }
 
@@ -448,10 +447,10 @@ class NetworkApi {
   }) async {
     await _client.send('Network.deleteCookies', {
       'name': name,
-      if (url != null) 'url': url,
-      if (domain != null) 'domain': domain,
-      if (path != null) 'path': path,
-      if (partitionKey != null) 'partitionKey': partitionKey,
+      'url': ?url,
+      'domain': ?domain,
+      'path': ?path,
+      'partitionKey': ?partitionKey,
     });
   }
 
@@ -486,10 +485,10 @@ class NetworkApi {
       'latency': latency,
       'downloadThroughput': downloadThroughput,
       'uploadThroughput': uploadThroughput,
-      if (connectionType != null) 'connectionType': connectionType,
-      if (packetLoss != null) 'packetLoss': packetLoss,
-      if (packetQueueLength != null) 'packetQueueLength': packetQueueLength,
-      if (packetReordering != null) 'packetReordering': packetReordering,
+      'connectionType': ?connectionType,
+      'packetLoss': ?packetLoss,
+      'packetQueueLength': ?packetQueueLength,
+      'packetReordering': ?packetReordering,
     });
   }
 
@@ -512,9 +511,8 @@ class NetworkApi {
   }) async {
     var result = await _client.send('Network.emulateNetworkConditionsByRule', {
       'matchedNetworkConditions': [...matchedNetworkConditions],
-      if (offline != null) 'offline': offline,
-      if (emulateOfflineServiceWorker != null)
-        'emulateOfflineServiceWorker': emulateOfflineServiceWorker,
+      'offline': ?offline,
+      'emulateOfflineServiceWorker': ?emulateOfflineServiceWorker,
     });
     return (result['ruleIds'] as List).map((e) => e as String).toList();
   }
@@ -537,7 +535,7 @@ class NetworkApi {
       'latency': latency,
       'downloadThroughput': downloadThroughput,
       'uploadThroughput': uploadThroughput,
-      if (connectionType != null) 'connectionType': connectionType,
+      'connectionType': ?connectionType,
     });
   }
 
@@ -561,14 +559,11 @@ class NetworkApi {
     bool? enableDurableMessages,
   }) async {
     await _client.send('Network.enable', {
-      if (maxTotalBufferSize != null) 'maxTotalBufferSize': maxTotalBufferSize,
-      if (maxResourceBufferSize != null)
-        'maxResourceBufferSize': maxResourceBufferSize,
-      if (maxPostDataSize != null) 'maxPostDataSize': maxPostDataSize,
-      if (reportDirectSocketTraffic != null)
-        'reportDirectSocketTraffic': reportDirectSocketTraffic,
-      if (enableDurableMessages != null)
-        'enableDurableMessages': enableDurableMessages,
+      'maxTotalBufferSize': ?maxTotalBufferSize,
+      'maxResourceBufferSize': ?maxResourceBufferSize,
+      'maxPostDataSize': ?maxPostDataSize,
+      'reportDirectSocketTraffic': ?reportDirectSocketTraffic,
+      'enableDurableMessages': ?enableDurableMessages,
     });
   }
 
@@ -582,9 +577,8 @@ class NetworkApi {
     int? maxResourceBufferSize,
   }) async {
     await _client.send('Network.configureDurableMessages', {
-      if (maxTotalBufferSize != null) 'maxTotalBufferSize': maxTotalBufferSize,
-      if (maxResourceBufferSize != null)
-        'maxResourceBufferSize': maxResourceBufferSize,
+      'maxTotalBufferSize': ?maxTotalBufferSize,
+      'maxResourceBufferSize': ?maxResourceBufferSize,
     });
   }
 
@@ -692,8 +686,8 @@ class NetworkApi {
     var result = await _client.send('Network.searchInResponseBody', {
       'requestId': requestId,
       'query': query,
-      if (caseSensitive != null) 'caseSensitive': caseSensitive,
-      if (isRegex != null) 'isRegex': isRegex,
+      'caseSensitive': ?caseSensitive,
+      'isRegex': ?isRegex,
     });
     return (result['result'] as List)
         .map((e) => debugger.SearchMatch.fromJson(e as Map<String, dynamic>))
@@ -763,17 +757,17 @@ class NetworkApi {
     var result = await _client.send('Network.setCookie', {
       'name': name,
       'value': value,
-      if (url != null) 'url': url,
-      if (domain != null) 'domain': domain,
-      if (path != null) 'path': path,
-      if (secure != null) 'secure': secure,
-      if (httpOnly != null) 'httpOnly': httpOnly,
-      if (sameSite != null) 'sameSite': sameSite,
-      if (expires != null) 'expires': expires,
-      if (priority != null) 'priority': priority,
-      if (sourceScheme != null) 'sourceScheme': sourceScheme,
-      if (sourcePort != null) 'sourcePort': sourcePort,
-      if (partitionKey != null) 'partitionKey': partitionKey,
+      'url': ?url,
+      'domain': ?domain,
+      'path': ?path,
+      'secure': ?secure,
+      'httpOnly': ?httpOnly,
+      'sameSite': ?sameSite,
+      'expires': ?expires,
+      'priority': ?priority,
+      'sourceScheme': ?sourceScheme,
+      'sourcePort': ?sourcePort,
+      'partitionKey': ?partitionKey,
     });
     return result['success'] as bool;
   }
@@ -822,9 +816,9 @@ class NetworkApi {
   }) async {
     await _client.send('Network.setUserAgentOverride', {
       'userAgent': userAgent,
-      if (acceptLanguage != null) 'acceptLanguage': acceptLanguage,
-      if (platform != null) 'platform': platform,
-      if (userAgentMetadata != null) 'userAgentMetadata': userAgentMetadata,
+      'acceptLanguage': ?acceptLanguage,
+      'platform': ?platform,
+      'userAgentMetadata': ?userAgentMetadata,
     });
   }
 
@@ -845,7 +839,7 @@ class NetworkApi {
     page.FrameId? frameId,
   }) async {
     var result = await _client.send('Network.getSecurityIsolationStatus', {
-      if (frameId != null) 'frameId': frameId,
+      'frameId': ?frameId,
     });
     return SecurityIsolationStatus.fromJson(
       result['status'] as Map<String, dynamic>,
@@ -893,7 +887,7 @@ class NetworkApi {
     var result = await _client.send('Network.loadNetworkResource', {
       'url': url,
       'options': options,
-      if (frameId != null) 'frameId': frameId,
+      'frameId': ?frameId,
     });
     return LoadNetworkResourcePageResult.fromJson(
       result['resource'] as Map<String, dynamic>,

--- a/lib/protocol/overlay.dart
+++ b/lib/protocol/overlay.dart
@@ -84,11 +84,10 @@ class OverlayApi {
   }) async {
     var result = await _client.send('Overlay.getHighlightObjectForTest', {
       'nodeId': nodeId,
-      if (includeDistance != null) 'includeDistance': includeDistance,
-      if (includeStyle != null) 'includeStyle': includeStyle,
-      if (colorFormat != null) 'colorFormat': colorFormat,
-      if (showAccessibilityInfo != null)
-        'showAccessibilityInfo': showAccessibilityInfo,
+      'includeDistance': ?includeDistance,
+      'includeStyle': ?includeStyle,
+      'colorFormat': ?colorFormat,
+      'showAccessibilityInfo': ?showAccessibilityInfo,
     });
     return result['highlight'] as Map<String, dynamic>;
   }
@@ -138,9 +137,8 @@ class OverlayApi {
   }) async {
     await _client.send('Overlay.highlightFrame', {
       'frameId': frameId,
-      if (contentColor != null) 'contentColor': contentColor,
-      if (contentOutlineColor != null)
-        'contentOutlineColor': contentOutlineColor,
+      'contentColor': ?contentColor,
+      'contentOutlineColor': ?contentOutlineColor,
     });
   }
 
@@ -160,10 +158,10 @@ class OverlayApi {
   }) async {
     await _client.send('Overlay.highlightNode', {
       'highlightConfig': highlightConfig,
-      if (nodeId != null) 'nodeId': nodeId,
-      if (backendNodeId != null) 'backendNodeId': backendNodeId,
-      if (objectId != null) 'objectId': objectId,
-      if (selector != null) 'selector': selector,
+      'nodeId': ?nodeId,
+      'backendNodeId': ?backendNodeId,
+      'objectId': ?objectId,
+      'selector': ?selector,
     });
   }
 
@@ -178,8 +176,8 @@ class OverlayApi {
   }) async {
     await _client.send('Overlay.highlightQuad', {
       'quad': quad,
-      if (color != null) 'color': color,
-      if (outlineColor != null) 'outlineColor': outlineColor,
+      'color': ?color,
+      'outlineColor': ?outlineColor,
     });
   }
 
@@ -206,8 +204,8 @@ class OverlayApi {
       'y': y,
       'width': width,
       'height': height,
-      if (color != null) 'color': color,
-      if (outlineColor != null) 'outlineColor': outlineColor,
+      'color': ?color,
+      'outlineColor': ?outlineColor,
     });
   }
 
@@ -225,9 +223,9 @@ class OverlayApi {
   }) async {
     await _client.send('Overlay.highlightSourceOrder', {
       'sourceOrderConfig': sourceOrderConfig,
-      if (nodeId != null) 'nodeId': nodeId,
-      if (backendNodeId != null) 'backendNodeId': backendNodeId,
-      if (objectId != null) 'objectId': objectId,
+      'nodeId': ?nodeId,
+      'backendNodeId': ?backendNodeId,
+      'objectId': ?objectId,
     });
   }
 
@@ -242,7 +240,7 @@ class OverlayApi {
   }) async {
     await _client.send('Overlay.setInspectMode', {
       'mode': mode,
-      if (highlightConfig != null) 'highlightConfig': highlightConfig,
+      'highlightConfig': ?highlightConfig,
     });
   }
 
@@ -255,7 +253,7 @@ class OverlayApi {
   /// [message] The message to display, also triggers resume and step over controls.
   Future<void> setPausedInDebuggerMessage({String? message}) async {
     await _client.send('Overlay.setPausedInDebuggerMessage', {
-      if (message != null) 'message': message,
+      'message': ?message,
     });
   }
 
@@ -357,9 +355,7 @@ class OverlayApi {
   /// Add a dual screen device hinge
   /// [hingeConfig] hinge data, null means hideHinge
   Future<void> setShowHinge({HingeConfig? hingeConfig}) async {
-    await _client.send('Overlay.setShowHinge', {
-      if (hingeConfig != null) 'hingeConfig': hingeConfig,
-    });
+    await _client.send('Overlay.setShowHinge', {'hingeConfig': ?hingeConfig});
   }
 
   /// Add a display cutout overlay.
@@ -368,8 +364,7 @@ class OverlayApi {
     DisplayCutoutConfig? displayCutoutConfig,
   }) async {
     await _client.send('Overlay.setShowDisplayCutout', {
-      if (displayCutoutConfig != null)
-        'displayCutoutConfig': displayCutoutConfig,
+      'displayCutoutConfig': ?displayCutoutConfig,
     });
   }
 
@@ -389,8 +384,7 @@ class OverlayApi {
     WindowControlsOverlayConfig? windowControlsOverlayConfig,
   }) async {
     await _client.send('Overlay.setShowWindowControlsOverlay', {
-      if (windowControlsOverlayConfig != null)
-        'windowControlsOverlayConfig': windowControlsOverlayConfig,
+      'windowControlsOverlayConfig': ?windowControlsOverlayConfig,
     });
   }
 }

--- a/lib/protocol/page.dart
+++ b/lib/protocol/page.dart
@@ -219,10 +219,9 @@ class PageApi {
   }) async {
     var result = await _client.send('Page.addScriptToEvaluateOnNewDocument', {
       'source': source,
-      if (worldName != null) 'worldName': worldName,
-      if (includeCommandLineAPI != null)
-        'includeCommandLineAPI': includeCommandLineAPI,
-      if (runImmediately != null) 'runImmediately': runImmediately,
+      'worldName': ?worldName,
+      'includeCommandLineAPI': ?includeCommandLineAPI,
+      'runImmediately': ?runImmediately,
     });
     return ScriptIdentifier.fromJson(result['identifier'] as String);
   }
@@ -250,13 +249,12 @@ class PageApi {
   }) async {
     assert(format == null || const ['jpeg', 'png', 'webp'].contains(format));
     var result = await _client.send('Page.captureScreenshot', {
-      if (format != null) 'format': format,
-      if (quality != null) 'quality': quality,
-      if (clip != null) 'clip': clip,
-      if (fromSurface != null) 'fromSurface': fromSurface,
-      if (captureBeyondViewport != null)
-        'captureBeyondViewport': captureBeyondViewport,
-      if (optimizeForSpeed != null) 'optimizeForSpeed': optimizeForSpeed,
+      'format': ?format,
+      'quality': ?quality,
+      'clip': ?clip,
+      'fromSurface': ?fromSurface,
+      'captureBeyondViewport': ?captureBeyondViewport,
+      'optimizeForSpeed': ?optimizeForSpeed,
     });
     return result['data'] as String;
   }
@@ -268,7 +266,7 @@ class PageApi {
   Future<String> captureSnapshot({@Enum(['mhtml']) String? format}) async {
     assert(format == null || const ['mhtml'].contains(format));
     var result = await _client.send('Page.captureSnapshot', {
-      if (format != null) 'format': format,
+      'format': ?format,
     });
     return result['data'] as String;
   }
@@ -311,11 +309,9 @@ class PageApi {
   }) async {
     var result = await _client.send('Page.createIsolatedWorld', {
       'frameId': frameId,
-      if (worldName != null) 'worldName': worldName,
-      if (grantUniveralAccess != null)
-        'grantUniveralAccess': grantUniveralAccess,
-      if (contentSecurityPolicy != null)
-        'contentSecurityPolicy': contentSecurityPolicy,
+      'worldName': ?worldName,
+      'grantUniveralAccess': ?grantUniveralAccess,
+      'contentSecurityPolicy': ?contentSecurityPolicy,
     });
     return runtime.ExecutionContextId.fromJson(
       result['executionContextId'] as int,
@@ -343,8 +339,7 @@ class PageApi {
   /// `Page.setInterceptFileChooserDialog` command (default: false).
   Future<void> enable({bool? enableFileChooserOpenedEvent}) async {
     await _client.send('Page.enable', {
-      if (enableFileChooserOpenedEvent != null)
-        'enableFileChooserOpenedEvent': enableFileChooserOpenedEvent,
+      'enableFileChooserOpenedEvent': ?enableFileChooserOpenedEvent,
     });
   }
 
@@ -355,7 +350,7 @@ class PageApi {
   ///   If there is not a loaded page, this API errors out immediately.
   Future<GetAppManifestResult> getAppManifest({String? manifestId}) async {
     var result = await _client.send('Page.getAppManifest', {
-      if (manifestId != null) 'manifestId': manifestId,
+      'manifestId': ?manifestId,
     });
     return GetAppManifestResult.fromJson(result);
   }
@@ -449,7 +444,7 @@ class PageApi {
   Future<void> handleJavaScriptDialog(bool accept, {String? promptText}) async {
     await _client.send('Page.handleJavaScriptDialog', {
       'accept': accept,
-      if (promptText != null) 'promptText': promptText,
+      'promptText': ?promptText,
     });
   }
 
@@ -468,10 +463,10 @@ class PageApi {
   }) async {
     var result = await _client.send('Page.navigate', {
       'url': url,
-      if (referrer != null) 'referrer': referrer,
-      if (transitionType != null) 'transitionType': transitionType,
-      if (frameId != null) 'frameId': frameId,
-      if (referrerPolicy != null) 'referrerPolicy': referrerPolicy,
+      'referrer': ?referrer,
+      'transitionType': ?transitionType,
+      'frameId': ?frameId,
+      'referrerPolicy': ?referrerPolicy,
     });
     return NavigateResult.fromJson(result);
   }
@@ -540,25 +535,23 @@ class PageApi {
           const ['ReturnAsBase64', 'ReturnAsStream'].contains(transferMode),
     );
     var result = await _client.send('Page.printToPDF', {
-      if (landscape != null) 'landscape': landscape,
-      if (displayHeaderFooter != null)
-        'displayHeaderFooter': displayHeaderFooter,
-      if (printBackground != null) 'printBackground': printBackground,
-      if (scale != null) 'scale': scale,
-      if (paperWidth != null) 'paperWidth': paperWidth,
-      if (paperHeight != null) 'paperHeight': paperHeight,
-      if (marginTop != null) 'marginTop': marginTop,
-      if (marginBottom != null) 'marginBottom': marginBottom,
-      if (marginLeft != null) 'marginLeft': marginLeft,
-      if (marginRight != null) 'marginRight': marginRight,
-      if (pageRanges != null) 'pageRanges': pageRanges,
-      if (headerTemplate != null) 'headerTemplate': headerTemplate,
-      if (footerTemplate != null) 'footerTemplate': footerTemplate,
-      if (preferCSSPageSize != null) 'preferCSSPageSize': preferCSSPageSize,
-      if (transferMode != null) 'transferMode': transferMode,
-      if (generateTaggedPDF != null) 'generateTaggedPDF': generateTaggedPDF,
-      if (generateDocumentOutline != null)
-        'generateDocumentOutline': generateDocumentOutline,
+      'landscape': ?landscape,
+      'displayHeaderFooter': ?displayHeaderFooter,
+      'printBackground': ?printBackground,
+      'scale': ?scale,
+      'paperWidth': ?paperWidth,
+      'paperHeight': ?paperHeight,
+      'marginTop': ?marginTop,
+      'marginBottom': ?marginBottom,
+      'marginLeft': ?marginLeft,
+      'marginRight': ?marginRight,
+      'pageRanges': ?pageRanges,
+      'headerTemplate': ?headerTemplate,
+      'footerTemplate': ?footerTemplate,
+      'preferCSSPageSize': ?preferCSSPageSize,
+      'transferMode': ?transferMode,
+      'generateTaggedPDF': ?generateTaggedPDF,
+      'generateDocumentOutline': ?generateDocumentOutline,
     });
     return PrintToPDFResult.fromJson(result);
   }
@@ -576,10 +569,9 @@ class PageApi {
     network.LoaderId? loaderId,
   }) async {
     await _client.send('Page.reload', {
-      if (ignoreCache != null) 'ignoreCache': ignoreCache,
-      if (scriptToEvaluateOnLoad != null)
-        'scriptToEvaluateOnLoad': scriptToEvaluateOnLoad,
-      if (loaderId != null) 'loaderId': loaderId,
+      'ignoreCache': ?ignoreCache,
+      'scriptToEvaluateOnLoad': ?scriptToEvaluateOnLoad,
+      'loaderId': ?loaderId,
     });
   }
 
@@ -624,8 +616,8 @@ class PageApi {
       'frameId': frameId,
       'url': url,
       'query': query,
-      if (caseSensitive != null) 'caseSensitive': caseSensitive,
-      if (isRegex != null) 'isRegex': isRegex,
+      'caseSensitive': ?caseSensitive,
+      'isRegex': ?isRegex,
     });
     return (result['result'] as List)
         .map((e) => debugger.SearchMatch.fromJson(e as Map<String, dynamic>))
@@ -705,14 +697,14 @@ class PageApi {
       'height': height,
       'deviceScaleFactor': deviceScaleFactor,
       'mobile': mobile,
-      if (scale != null) 'scale': scale,
-      if (screenWidth != null) 'screenWidth': screenWidth,
-      if (screenHeight != null) 'screenHeight': screenHeight,
-      if (positionX != null) 'positionX': positionX,
-      if (positionY != null) 'positionY': positionY,
-      if (dontSetVisibleSize != null) 'dontSetVisibleSize': dontSetVisibleSize,
-      if (screenOrientation != null) 'screenOrientation': screenOrientation,
-      if (viewport != null) 'viewport': viewport,
+      'scale': ?scale,
+      'screenWidth': ?screenWidth,
+      'screenHeight': ?screenHeight,
+      'positionX': ?positionX,
+      'positionY': ?positionY,
+      'dontSetVisibleSize': ?dontSetVisibleSize,
+      'screenOrientation': ?screenOrientation,
+      'viewport': ?viewport,
     });
   }
 
@@ -774,7 +766,7 @@ class PageApi {
     assert(const ['deny', 'allow', 'default'].contains(behavior));
     await _client.send('Page.setDownloadBehavior', {
       'behavior': behavior,
-      if (downloadPath != null) 'downloadPath': downloadPath,
+      'downloadPath': ?downloadPath,
     });
   }
 
@@ -790,9 +782,9 @@ class PageApi {
     num? accuracy,
   }) async {
     await _client.send('Page.setGeolocationOverride', {
-      if (latitude != null) 'latitude': latitude,
-      if (longitude != null) 'longitude': longitude,
-      if (accuracy != null) 'accuracy': accuracy,
+      'latitude': ?latitude,
+      'longitude': ?longitude,
+      'accuracy': ?accuracy,
     });
   }
 
@@ -816,7 +808,7 @@ class PageApi {
     );
     await _client.send('Page.setTouchEmulationEnabled', {
       'enabled': enabled,
-      if (configuration != null) 'configuration': configuration,
+      'configuration': ?configuration,
     });
   }
 
@@ -835,11 +827,11 @@ class PageApi {
   }) async {
     assert(format == null || const ['jpeg', 'png'].contains(format));
     await _client.send('Page.startScreencast', {
-      if (format != null) 'format': format,
-      if (quality != null) 'quality': quality,
-      if (maxWidth != null) 'maxWidth': maxWidth,
-      if (maxHeight != null) 'maxHeight': maxHeight,
-      if (everyNthFrame != null) 'everyNthFrame': everyNthFrame,
+      'format': ?format,
+      'quality': ?quality,
+      'maxWidth': ?maxWidth,
+      'maxHeight': ?maxHeight,
+      'everyNthFrame': ?everyNthFrame,
     });
   }
 
@@ -939,7 +931,7 @@ class PageApi {
   Future<void> generateTestReport(String message, {String? group}) async {
     await _client.send('Page.generateTestReport', {
       'message': message,
-      if (group != null) 'group': group,
+      'group': ?group,
     });
   }
 
@@ -960,7 +952,7 @@ class PageApi {
   }) async {
     await _client.send('Page.setInterceptFileChooserDialog', {
       'enabled': enabled,
-      if (cancel != null) 'cancel': cancel,
+      'cancel': ?cancel,
     });
   }
 
@@ -985,8 +977,7 @@ class PageApi {
     bool? includeActionableInformation,
   }) async {
     var result = await _client.send('Page.getAnnotatedPageContent', {
-      if (includeActionableInformation != null)
-        'includeActionableInformation': includeActionableInformation,
+      'includeActionableInformation': ?includeActionableInformation,
     });
     return result['content'] as String;
   }

--- a/lib/protocol/performance.dart
+++ b/lib/protocol/performance.dart
@@ -25,9 +25,7 @@ class PerformanceApi {
       timeDomain == null ||
           const ['timeTicks', 'threadTicks'].contains(timeDomain),
     );
-    await _client.send('Performance.enable', {
-      if (timeDomain != null) 'timeDomain': timeDomain,
-    });
+    await _client.send('Performance.enable', {'timeDomain': ?timeDomain});
   }
 
   /// Sets time domain to use for collecting and reporting duration metrics.

--- a/lib/protocol/profiler.dart
+++ b/lib/protocol/profiler.dart
@@ -72,10 +72,9 @@ class ProfilerApi {
     bool? allowTriggeredUpdates,
   }) async {
     var result = await _client.send('Profiler.startPreciseCoverage', {
-      if (callCount != null) 'callCount': callCount,
-      if (detailed != null) 'detailed': detailed,
-      if (allowTriggeredUpdates != null)
-        'allowTriggeredUpdates': allowTriggeredUpdates,
+      'callCount': ?callCount,
+      'detailed': ?detailed,
+      'allowTriggeredUpdates': ?allowTriggeredUpdates,
     });
     return result['timestamp'] as num;
   }

--- a/lib/protocol/pwa.dart
+++ b/lib/protocol/pwa.dart
@@ -53,8 +53,7 @@ class PWAApi {
   }) async {
     await _client.send('PWA.install', {
       'manifestId': manifestId,
-      if (installUrlOrBundleUrl != null)
-        'installUrlOrBundleUrl': installUrlOrBundleUrl,
+      'installUrlOrBundleUrl': ?installUrlOrBundleUrl,
     });
   }
 
@@ -70,7 +69,7 @@ class PWAApi {
   Future<target.TargetID> launch(String manifestId, {String? url}) async {
     var result = await _client.send('PWA.launch', {
       'manifestId': manifestId,
-      if (url != null) 'url': url,
+      'url': ?url,
     });
     return target.TargetID.fromJson(result['targetId'] as String);
   }
@@ -136,8 +135,8 @@ class PWAApi {
   }) async {
     await _client.send('PWA.changeAppUserSettings', {
       'manifestId': manifestId,
-      if (linkCapturing != null) 'linkCapturing': linkCapturing,
-      if (displayMode != null) 'displayMode': displayMode,
+      'linkCapturing': ?linkCapturing,
+      'displayMode': ?displayMode,
     });
   }
 }

--- a/lib/protocol/runtime.dart
+++ b/lib/protocol/runtime.dart
@@ -72,8 +72,8 @@ class RuntimeApi {
   }) async {
     var result = await _client.send('Runtime.awaitPromise', {
       'promiseObjectId': promiseObjectId,
-      if (returnByValue != null) 'returnByValue': returnByValue,
-      if (generatePreview != null) 'generatePreview': generatePreview,
+      'returnByValue': ?returnByValue,
+      'generatePreview': ?generatePreview,
     });
     return AwaitPromiseResult.fromJson(result);
   }
@@ -123,19 +123,18 @@ class RuntimeApi {
   }) async {
     var result = await _client.send('Runtime.callFunctionOn', {
       'functionDeclaration': functionDeclaration,
-      if (objectId != null) 'objectId': objectId,
+      'objectId': ?objectId,
       if (arguments != null) 'arguments': [...arguments],
-      if (silent != null) 'silent': silent,
-      if (returnByValue != null) 'returnByValue': returnByValue,
-      if (generatePreview != null) 'generatePreview': generatePreview,
-      if (userGesture != null) 'userGesture': userGesture,
-      if (awaitPromise != null) 'awaitPromise': awaitPromise,
-      if (executionContextId != null) 'executionContextId': executionContextId,
-      if (objectGroup != null) 'objectGroup': objectGroup,
-      if (throwOnSideEffect != null) 'throwOnSideEffect': throwOnSideEffect,
-      if (uniqueContextId != null) 'uniqueContextId': uniqueContextId,
-      if (serializationOptions != null)
-        'serializationOptions': serializationOptions,
+      'silent': ?silent,
+      'returnByValue': ?returnByValue,
+      'generatePreview': ?generatePreview,
+      'userGesture': ?userGesture,
+      'awaitPromise': ?awaitPromise,
+      'executionContextId': ?executionContextId,
+      'objectGroup': ?objectGroup,
+      'throwOnSideEffect': ?throwOnSideEffect,
+      'uniqueContextId': ?uniqueContextId,
+      'serializationOptions': ?serializationOptions,
     });
     return CallFunctionOnResult.fromJson(result);
   }
@@ -156,7 +155,7 @@ class RuntimeApi {
       'expression': expression,
       'sourceURL': sourceURL,
       'persistScript': persistScript,
-      if (executionContextId != null) 'executionContextId': executionContextId,
+      'executionContextId': ?executionContextId,
     });
     return CompileScriptResult.fromJson(result);
   }
@@ -233,24 +232,21 @@ class RuntimeApi {
   }) async {
     var result = await _client.send('Runtime.evaluate', {
       'expression': expression,
-      if (objectGroup != null) 'objectGroup': objectGroup,
-      if (includeCommandLineAPI != null)
-        'includeCommandLineAPI': includeCommandLineAPI,
-      if (silent != null) 'silent': silent,
-      if (contextId != null) 'contextId': contextId,
-      if (returnByValue != null) 'returnByValue': returnByValue,
-      if (generatePreview != null) 'generatePreview': generatePreview,
-      if (userGesture != null) 'userGesture': userGesture,
-      if (awaitPromise != null) 'awaitPromise': awaitPromise,
-      if (throwOnSideEffect != null) 'throwOnSideEffect': throwOnSideEffect,
-      if (timeout != null) 'timeout': timeout,
-      if (disableBreaks != null) 'disableBreaks': disableBreaks,
-      if (replMode != null) 'replMode': replMode,
-      if (allowUnsafeEvalBlockedByCSP != null)
-        'allowUnsafeEvalBlockedByCSP': allowUnsafeEvalBlockedByCSP,
-      if (uniqueContextId != null) 'uniqueContextId': uniqueContextId,
-      if (serializationOptions != null)
-        'serializationOptions': serializationOptions,
+      'objectGroup': ?objectGroup,
+      'includeCommandLineAPI': ?includeCommandLineAPI,
+      'silent': ?silent,
+      'contextId': ?contextId,
+      'returnByValue': ?returnByValue,
+      'generatePreview': ?generatePreview,
+      'userGesture': ?userGesture,
+      'awaitPromise': ?awaitPromise,
+      'throwOnSideEffect': ?throwOnSideEffect,
+      'timeout': ?timeout,
+      'disableBreaks': ?disableBreaks,
+      'replMode': ?replMode,
+      'allowUnsafeEvalBlockedByCSP': ?allowUnsafeEvalBlockedByCSP,
+      'uniqueContextId': ?uniqueContextId,
+      'serializationOptions': ?serializationOptions,
     });
     return EvaluateResult.fromJson(result);
   }
@@ -287,12 +283,10 @@ class RuntimeApi {
   }) async {
     var result = await _client.send('Runtime.getProperties', {
       'objectId': objectId,
-      if (ownProperties != null) 'ownProperties': ownProperties,
-      if (accessorPropertiesOnly != null)
-        'accessorPropertiesOnly': accessorPropertiesOnly,
-      if (generatePreview != null) 'generatePreview': generatePreview,
-      if (nonIndexedPropertiesOnly != null)
-        'nonIndexedPropertiesOnly': nonIndexedPropertiesOnly,
+      'ownProperties': ?ownProperties,
+      'accessorPropertiesOnly': ?accessorPropertiesOnly,
+      'generatePreview': ?generatePreview,
+      'nonIndexedPropertiesOnly': ?nonIndexedPropertiesOnly,
     });
     return GetPropertiesResult.fromJson(result);
   }
@@ -303,7 +297,7 @@ class RuntimeApi {
     ExecutionContextId? executionContextId,
   }) async {
     var result = await _client.send('Runtime.globalLexicalScopeNames', {
-      if (executionContextId != null) 'executionContextId': executionContextId,
+      'executionContextId': ?executionContextId,
     });
     return (result['names'] as List).map((e) => e as String).toList();
   }
@@ -317,7 +311,7 @@ class RuntimeApi {
   }) async {
     var result = await _client.send('Runtime.queryObjects', {
       'prototypeObjectId': prototypeObjectId,
-      if (objectGroup != null) 'objectGroup': objectGroup,
+      'objectGroup': ?objectGroup,
     });
     return RemoteObject.fromJson(result['objects'] as Map<String, dynamic>);
   }
@@ -365,14 +359,13 @@ class RuntimeApi {
   }) async {
     var result = await _client.send('Runtime.runScript', {
       'scriptId': scriptId,
-      if (executionContextId != null) 'executionContextId': executionContextId,
-      if (objectGroup != null) 'objectGroup': objectGroup,
-      if (silent != null) 'silent': silent,
-      if (includeCommandLineAPI != null)
-        'includeCommandLineAPI': includeCommandLineAPI,
-      if (returnByValue != null) 'returnByValue': returnByValue,
-      if (generatePreview != null) 'generatePreview': generatePreview,
-      if (awaitPromise != null) 'awaitPromise': awaitPromise,
+      'executionContextId': ?executionContextId,
+      'objectGroup': ?objectGroup,
+      'silent': ?silent,
+      'includeCommandLineAPI': ?includeCommandLineAPI,
+      'returnByValue': ?returnByValue,
+      'generatePreview': ?generatePreview,
+      'awaitPromise': ?awaitPromise,
     });
     return RunScriptResult.fromJson(result);
   }
@@ -421,9 +414,8 @@ class RuntimeApi {
   }) async {
     await _client.send('Runtime.addBinding', {
       'name': name,
-      if (executionContextId != null) 'executionContextId': executionContextId,
-      if (executionContextName != null)
-        'executionContextName': executionContextName,
+      'executionContextId': ?executionContextId,
+      'executionContextName': ?executionContextName,
     });
   }
 

--- a/lib/protocol/smart_card_emulation.dart
+++ b/lib/protocol/smart_card_emulation.dart
@@ -274,7 +274,7 @@ class SmartCardEmulationApi {
     await _client.send('SmartCardEmulation.reportConnectResult', {
       'requestId': requestId,
       'handle': handle,
-      if (activeProtocol != null) 'activeProtocol': activeProtocol,
+      'activeProtocol': ?activeProtocol,
     });
   }
 
@@ -317,7 +317,7 @@ class SmartCardEmulationApi {
       'readerName': readerName,
       'state': state,
       'atr': atr,
-      if (protocol != null) 'protocol': protocol,
+      'protocol': ?protocol,
     });
   }
 

--- a/lib/protocol/storage.dart
+++ b/lib/protocol/storage.dart
@@ -123,7 +123,7 @@ class StorageApi {
   /// the storage key of the target executing this command is returned.
   Future<SerializedStorageKey> getStorageKey({page.FrameId? frameId}) async {
     var result = await _client.send('Storage.getStorageKey', {
-      if (frameId != null) 'frameId': frameId,
+      'frameId': ?frameId,
     });
     return SerializedStorageKey.fromJson(result['storageKey'] as String);
   }
@@ -158,7 +158,7 @@ class StorageApi {
     browser.BrowserContextID? browserContextId,
   }) async {
     var result = await _client.send('Storage.getCookies', {
-      if (browserContextId != null) 'browserContextId': browserContextId,
+      'browserContextId': ?browserContextId,
     });
     return (result['cookies'] as List)
         .map((e) => network.Cookie.fromJson(e as Map<String, dynamic>))
@@ -174,7 +174,7 @@ class StorageApi {
   }) async {
     await _client.send('Storage.setCookies', {
       'cookies': [...cookies],
-      if (browserContextId != null) 'browserContextId': browserContextId,
+      'browserContextId': ?browserContextId,
     });
   }
 
@@ -184,7 +184,7 @@ class StorageApi {
     browser.BrowserContextID? browserContextId,
   }) async {
     await _client.send('Storage.clearCookies', {
-      if (browserContextId != null) 'browserContextId': browserContextId,
+      'browserContextId': ?browserContextId,
     });
   }
 
@@ -209,7 +209,7 @@ class StorageApi {
   Future<void> overrideQuotaForOrigin(String origin, {num? quotaSize}) async {
     await _client.send('Storage.overrideQuotaForOrigin', {
       'origin': origin,
-      if (quotaSize != null) 'quotaSize': quotaSize,
+      'quotaSize': ?quotaSize,
     });
   }
 
@@ -358,7 +358,7 @@ class StorageApi {
       'ownerOrigin': ownerOrigin,
       'key': key,
       'value': value,
-      if (ignoreIfPresent != null) 'ignoreIfPresent': ignoreIfPresent,
+      'ignoreIfPresent': ?ignoreIfPresent,
     });
   }
 

--- a/lib/protocol/target.dart
+++ b/lib/protocol/target.dart
@@ -74,7 +74,7 @@ class TargetApi {
   Future<SessionID> attachToTarget(TargetID targetId, {bool? flatten}) async {
     var result = await _client.send('Target.attachToTarget', {
       'targetId': targetId,
-      if (flatten != null) 'flatten': flatten,
+      'flatten': ?flatten,
     });
     return SessionID.fromJson(result['sessionId'] as String);
   }
@@ -112,8 +112,8 @@ class TargetApi {
   }) async {
     await _client.send('Target.exposeDevToolsProtocol', {
       'targetId': targetId,
-      if (bindingName != null) 'bindingName': bindingName,
-      if (inheritPermissions != null) 'inheritPermissions': inheritPermissions,
+      'bindingName': ?bindingName,
+      'inheritPermissions': ?inheritPermissions,
     });
   }
 
@@ -132,9 +132,9 @@ class TargetApi {
     List<String>? originsWithUniversalNetworkAccess,
   }) async {
     var result = await _client.send('Target.createBrowserContext', {
-      if (disposeOnDetach != null) 'disposeOnDetach': disposeOnDetach,
-      if (proxyServer != null) 'proxyServer': proxyServer,
-      if (proxyBypassList != null) 'proxyBypassList': proxyBypassList,
+      'disposeOnDetach': ?disposeOnDetach,
+      'proxyServer': ?proxyServer,
+      'proxyBypassList': ?proxyBypassList,
       if (originsWithUniversalNetworkAccess != null)
         'originsWithUniversalNetworkAccess': [
           ...originsWithUniversalNetworkAccess,
@@ -192,19 +192,18 @@ class TargetApi {
   }) async {
     var result = await _client.send('Target.createTarget', {
       'url': url,
-      if (left != null) 'left': left,
-      if (top != null) 'top': top,
-      if (width != null) 'width': width,
-      if (height != null) 'height': height,
-      if (windowState != null) 'windowState': windowState,
-      if (browserContextId != null) 'browserContextId': browserContextId,
-      if (enableBeginFrameControl != null)
-        'enableBeginFrameControl': enableBeginFrameControl,
-      if (newWindow != null) 'newWindow': newWindow,
-      if (background != null) 'background': background,
-      if (forTab != null) 'forTab': forTab,
-      if (hidden != null) 'hidden': hidden,
-      if (focus != null) 'focus': focus,
+      'left': ?left,
+      'top': ?top,
+      'width': ?width,
+      'height': ?height,
+      'windowState': ?windowState,
+      'browserContextId': ?browserContextId,
+      'enableBeginFrameControl': ?enableBeginFrameControl,
+      'newWindow': ?newWindow,
+      'background': ?background,
+      'forTab': ?forTab,
+      'hidden': ?hidden,
+      'focus': ?focus,
     });
     return TargetID.fromJson(result['targetId'] as String);
   }
@@ -216,8 +215,8 @@ class TargetApi {
     @Deprecated('This parameter is deprecated') TargetID? targetId,
   }) async {
     await _client.send('Target.detachFromTarget', {
-      if (sessionId != null) 'sessionId': sessionId,
-      if (targetId != null) 'targetId': targetId,
+      'sessionId': ?sessionId,
+      'targetId': ?targetId,
     });
   }
 
@@ -234,7 +233,7 @@ class TargetApi {
   /// Returns information about a target.
   Future<TargetInfo> getTargetInfo({TargetID? targetId}) async {
     var result = await _client.send('Target.getTargetInfo', {
-      if (targetId != null) 'targetId': targetId,
+      'targetId': ?targetId,
     });
     return TargetInfo.fromJson(result['targetInfo'] as Map<String, dynamic>);
   }
@@ -245,9 +244,7 @@ class TargetApi {
   /// is used for consistency.
   /// Returns: The list of targets.
   Future<List<TargetInfo>> getTargets({TargetFilter? filter}) async {
-    var result = await _client.send('Target.getTargets', {
-      if (filter != null) 'filter': filter,
-    });
+    var result = await _client.send('Target.getTargets', {'filter': ?filter});
     return (result['targetInfos'] as List)
         .map((e) => TargetInfo.fromJson(e as Map<String, dynamic>))
         .toList();
@@ -265,8 +262,8 @@ class TargetApi {
   }) async {
     await _client.send('Target.sendMessageToTarget', {
       'message': message,
-      if (sessionId != null) 'sessionId': sessionId,
-      if (targetId != null) 'targetId': targetId,
+      'sessionId': ?sessionId,
+      'targetId': ?targetId,
     });
   }
 
@@ -294,8 +291,8 @@ class TargetApi {
     await _client.send('Target.setAutoAttach', {
       'autoAttach': autoAttach,
       'waitForDebuggerOnStart': waitForDebuggerOnStart,
-      if (flatten != null) 'flatten': flatten,
-      if (filter != null) 'filter': filter,
+      'flatten': ?flatten,
+      'filter': ?filter,
     });
   }
 
@@ -315,7 +312,7 @@ class TargetApi {
     await _client.send('Target.autoAttachRelated', {
       'targetId': targetId,
       'waitForDebuggerOnStart': waitForDebuggerOnStart,
-      if (filter != null) 'filter': filter,
+      'filter': ?filter,
     });
   }
 
@@ -327,7 +324,7 @@ class TargetApi {
   Future<void> setDiscoverTargets(bool discover, {TargetFilter? filter}) async {
     await _client.send('Target.setDiscoverTargets', {
       'discover': discover,
-      if (filter != null) 'filter': filter,
+      'filter': ?filter,
     });
   }
 
@@ -360,7 +357,7 @@ class TargetApi {
   Future<TargetID> openDevTools(TargetID targetId, {String? panelId}) async {
     var result = await _client.send('Target.openDevTools', {
       'targetId': targetId,
-      if (panelId != null) 'panelId': panelId,
+      'panelId': ?panelId,
     });
     return TargetID.fromJson(result['targetId'] as String);
   }

--- a/lib/protocol/tracing.dart
+++ b/lib/protocol/tracing.dart
@@ -60,8 +60,8 @@ class TracingApi {
     MemoryDumpLevelOfDetail? levelOfDetail,
   }) async {
     var result = await _client.send('Tracing.requestMemoryDump', {
-      if (deterministic != null) 'deterministic': deterministic,
-      if (levelOfDetail != null) 'levelOfDetail': levelOfDetail,
+      'deterministic': ?deterministic,
+      'levelOfDetail': ?levelOfDetail,
     });
     return RequestMemoryDumpResult.fromJson(result);
   }
@@ -105,18 +105,17 @@ class TracingApi {
           const ['ReportEvents', 'ReturnAsStream'].contains(transferMode),
     );
     await _client.send('Tracing.start', {
-      if (categories != null) 'categories': categories,
-      if (options != null) 'options': options,
-      if (bufferUsageReportingInterval != null)
-        'bufferUsageReportingInterval': bufferUsageReportingInterval,
-      if (transferMode != null) 'transferMode': transferMode,
-      if (streamFormat != null) 'streamFormat': streamFormat,
-      if (streamCompression != null) 'streamCompression': streamCompression,
-      if (traceConfig != null) 'traceConfig': traceConfig,
-      if (perfettoConfig != null) 'perfettoConfig': perfettoConfig,
-      if (tracingBackend != null) 'tracingBackend': tracingBackend,
-      if (screenshotMaxSize != null) 'screenshotMaxSize': screenshotMaxSize,
-      if (screenshotMaxCount != null) 'screenshotMaxCount': screenshotMaxCount,
+      'categories': ?categories,
+      'options': ?options,
+      'bufferUsageReportingInterval': ?bufferUsageReportingInterval,
+      'transferMode': ?transferMode,
+      'streamFormat': ?streamFormat,
+      'streamCompression': ?streamCompression,
+      'traceConfig': ?traceConfig,
+      'perfettoConfig': ?perfettoConfig,
+      'tracingBackend': ?tracingBackend,
+      'screenshotMaxSize': ?screenshotMaxSize,
+      'screenshotMaxCount': ?screenshotMaxCount,
     });
   }
 }

--- a/lib/protocol/web_authn.dart
+++ b/lib/protocol/web_authn.dart
@@ -38,9 +38,7 @@ class WebAuthnApi {
   /// Supported at the embedder's discretion if UI is available.
   /// Defaults to false.
   Future<void> enable({bool? enableUI}) async {
-    await _client.send('WebAuthn.enable', {
-      if (enableUI != null) 'enableUI': enableUI,
-    });
+    await _client.send('WebAuthn.enable', {'enableUI': ?enableUI});
   }
 
   /// Disable the WebAuthn domain.
@@ -73,9 +71,9 @@ class WebAuthnApi {
   }) async {
     await _client.send('WebAuthn.setResponseOverrideBits', {
       'authenticatorId': authenticatorId,
-      if (isBogusSignature != null) 'isBogusSignature': isBogusSignature,
-      if (isBadUV != null) 'isBadUV': isBadUV,
-      if (isBadUP != null) 'isBadUP': isBadUP,
+      'isBogusSignature': ?isBogusSignature,
+      'isBadUV': ?isBadUV,
+      'isBadUP': ?isBadUP,
     });
   }
 
@@ -177,8 +175,8 @@ class WebAuthnApi {
     await _client.send('WebAuthn.setCredentialProperties', {
       'authenticatorId': authenticatorId,
       'credentialId': credentialId,
-      if (backupEligibility != null) 'backupEligibility': backupEligibility,
-      if (backupState != null) 'backupState': backupState,
+      'backupEligibility': ?backupEligibility,
+      'backupState': ?backupState,
     });
   }
 }

--- a/lib/src/page/frame_manager.dart
+++ b/lib/src/page/frame_manager.dart
@@ -122,14 +122,15 @@ class FrameManager {
       return null;
     }
 
+    Object? error;
     try {
-      var error = await Future.any([navigate(), watcher.timeoutOrTermination]);
-
-      if (error != null) {
-        return Future.error(error);
-      }
+      error = await Future.any([navigate(), watcher.timeoutOrTermination]);
     } finally {
       watcher.dispose();
+    }
+
+    if (error != null) {
+      return Future.error(error);
     }
 
     return watcher.navigationResponse ??
@@ -147,18 +148,19 @@ class FrameManager {
       wait: wait,
       timeout: timeout ?? page.navigationTimeoutOrDefault,
     );
+    Exception? error;
     try {
-      var error = await Future.any([
+      error = await Future.any([
         watcher.timeoutOrTermination,
         watcher.sameDocumentNavigation,
         watcher.newDocumentNavigation,
       ]);
-
-      if (error != null) {
-        return Future.error(error);
-      }
     } finally {
       watcher.dispose();
+    }
+
+    if (error != null) {
+      return Future.error(error);
     }
 
     return watcher.navigationResponse ??

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,26 +5,26 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: f0bb5d1648339c8308cc0b9838d8456b3cfe5c91f9dc1a735b4d003269e5da9a
+      sha256: "9a3386eea899815698dd55995277cf7cb8572ee52b399a6edfb7ae2b50e5fc19"
       url: "https://pub.dev"
     source: hosted
-    version: "88.0.0"
+    version: "105.0.0"
   analyzer:
     dependency: "direct dev"
     description:
       name: analyzer
-      sha256: "0b7b9c329d2879f8f05d6c05b32ee9ec025f39b077864bdb5ac9a7b63418a98f"
+      sha256: "62993bed6eadbe9596c5c20d5c167e7bc563c5fe266657a04ddeb93bdb84f4c9"
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.1"
+    version: "14.1.0"
   archive:
     dependency: "direct main"
     description:
       name: archive
-      sha256: "2fde1607386ab523f7a36bb3e7edb43bd58e6edaf2ffb29d8a6d578b297fdbbd"
+      sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.7"
+    version: "4.0.9"
   args:
     dependency: transitive
     description:
@@ -37,10 +37,10 @@ packages:
     dependency: "direct main"
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.13.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -53,34 +53,34 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "5b887c55a0f734b433b3b2d89f9cd1f99eb636b17e268a5b4259258bc916504b"
+      sha256: b94f5da9ed3d081fd4ecc426c260998b5f4f4eb2f6d89b7e5472edef0b2b2a1b
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.10"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: "4f64382b97504dc2fcdf487d5aae33418e08b4703fc21249e4db6d804a4d0187"
+      sha256: "94eaf6708fe64408c632ef2689ca3777b112f9421306ccf4f8c84d7c5c9f83f8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.2"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "8e928697a82be082206edb0b9c99c5a4ad6bc31c9e9b8b2f291ae65cd4a25daa"
+      sha256: "79e05eaf15a48d7230b053a4363b8eaac0cc234bbd0134c3229455481f55cbc6"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.4"
+    version: "4.1.5"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "804c47c936df75e1911c19a4fb8c46fa8ff2b3099b9f2b2aa4726af3774f734b"
+      sha256: "90363d438bd9f84a4d5bbb83352251f57d2d9d771bc95a44e6a33fe25fa52774"
       url: "https://pub.dev"
     source: hosted
-    version: "2.8.0"
+    version: "2.16.0"
   built_collection:
     dependency: transitive
     description:
@@ -93,10 +93,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: a30f0a0e38671e89a492c44d005b5545b830a961575bbd8336d42869ff71066d
+      sha256: "31b24be6615ec7fcf70b3aa5a7469fe35826485e639a16dd7eb83ba30e4cc6a8"
       url: "https://pub.dev"
     source: hosted
-    version: "8.12.0"
+    version: "8.12.7"
   checked_yaml:
     dependency: transitive
     description:
@@ -113,14 +113,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
-  code_builder:
-    dependency: transitive
-    description:
-      name: code_builder
-      sha256: "0ec10bf4a89e4c613960bf1e8b42c64127021740fb21640c29c909826a5eea3e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.10.1"
   collection:
     dependency: "direct main"
     description:
@@ -141,34 +133,34 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d"
+      sha256: "956a3de0725ca232ad353565a8290d3357592bf4250f6f298a185e2d949c5d3d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.15.1"
   crypto:
     dependency: "direct dev"
     description:
       name: crypto
-      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
+      sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.6"
+    version: "3.0.7"
   dart_style:
     dependency: "direct dev"
     description:
       name: dart_style
-      sha256: c87dfe3d56f183ffe9106a18aebc6db431fc7c98c31a54b952a77f3d54a85697
+      sha256: "3f88fc9c96c568d631356507355a2d1e983ee000c9ac008bdcb39b5bf53ce777"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.12"
   ffi:
     dependency: transitive
     description:
       name: ffi
-      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
+      sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   file:
     dependency: transitive
     description:
@@ -213,10 +205,10 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.6.0"
   http_methods:
     dependency: transitive
     description:
@@ -245,10 +237,10 @@ packages:
     dependency: "direct dev"
     description:
       name: image
-      sha256: "4e973fcf4caae1a4be2fa0a13157aa38a8f9cb049db6529aa00b4d71abc4d928"
+      sha256: "6300175e00616bbc832e2fc91bfa4d776af5402c81c7151bee6905bb08473c52"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.4"
+    version: "4.9.1"
   io:
     dependency: transitive
     description:
@@ -257,30 +249,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   json_annotation:
     dependency: "direct dev"
     description:
       name: json_annotation
-      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
+      sha256: "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80"
       url: "https://pub.dev"
     source: hosted
-    version: "4.9.0"
+    version: "4.12.0"
   json_serializable:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: "33a040668b31b320aafa4822b7b1e177e163fc3c1e835c6750319d4ab23aa6fe"
+      sha256: e45aefa0324f08c683caafbb94b72837aa6193c61822799c916e45f4a263113d
       url: "https://pub.dev"
     source: hosted
-    version: "6.11.1"
+    version: "6.14.1"
   lints:
     dependency: "direct dev"
     description:
@@ -301,18 +285,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.20"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -333,10 +317,10 @@ packages:
     dependency: transitive
     description:
       name: package_config
-      sha256: f096c55ebb7deb7e384101542bfba8c52696c1b56fca2eb62827989ef2353bbc
+      sha256: ffcf4cf3d6c0b74ac43708d9f56625506e8a68aa935abe9d267a7330f320eb5d
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "3.0.0"
   path:
     dependency: "direct main"
     description:
@@ -349,26 +333,26 @@ packages:
     dependency: "direct main"
     description:
       name: petitparser
-      sha256: "1a97266a94f7350d30ae522c0af07890c70b8e62c71e8e3920d1db4d23c057d1"
+      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.1"
+    version: "7.0.2"
   pool:
     dependency: "direct main"
     description:
       name: pool
-      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      sha256: "978783255c543aa3586a1b3c21f6e9d720eb315376a915872c61ef8b5c20177d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.1"
+    version: "1.5.2"
   posix:
     dependency: transitive
     description:
       name: posix
-      sha256: "6323a5b0fa688b6a010df4905a56b00181479e6d10534cecfecede2aa55add61"
+      sha256: bc1bad54ad2b735816e31f8d4600cfde6c7839975085ddfbca48b6c9f7c4044e
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.3"
+    version: "6.5.2"
   pub_semver:
     dependency: "direct dev"
     description:
@@ -429,18 +413,18 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: ccf30b0c9fbcd79d8b6f5bfac23199fb354938436f62475e14aea0f29ee0f800
+      sha256: a603f1fb984a7391ae5978d1b92bfaaa08b350dca5c825256f925818f7943bf5
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.1"
+    version: "4.2.4"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
-      sha256: "6a3c6cc82073a8797f8c4dc4572146114a39652851c157db37e964d9c7038723"
+      sha256: "5e6f216fdf6376c9f3852381ae037499797a3385377d388b011dac98d303c67c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.8"
+    version: "1.3.13"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -461,10 +445,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
+      sha256: "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.1"
+    version: "1.10.2"
   stack_trace:
     dependency: transitive
     description:
@@ -509,26 +493,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "0d5ba5602ec3baa28c8ce365e1efc5575969c765f45c554a3e167dc7945b9c30"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.31.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "475610b2aa23c19687cce2961e44b0cc57cafe220f67c2b80201231b2a07fbe7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.13"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: a39c204a4fc7a7ccb04a2b985e359fda3cc37e45e0b8ac61c3fb1a05aa832132
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.19"
   typed_data:
     dependency: transitive
     description:
@@ -541,18 +525,18 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
+      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.2"
+    version: "15.2.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      sha256: "5bf046f41320ac97a469d506261797f35254fa61c641741ef32dacda98b7d39c"
+      sha256: "1398c9f081a753f9226febe8900fce8f7d0a67163334e1c94a2438339d79d635"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.3"
+    version: "1.2.1"
   web:
     dependency: "direct main"
     description:
@@ -589,10 +573,10 @@ packages:
     dependency: transitive
     description:
       name: xml
-      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      sha256: "67f0aff7be013d107995e9b75bf4e7f2c3ef2dfdb2c8e68024bba0a7fd5756a4"
       url: "https://pub.dev"
     source: hosted
-    version: "6.6.1"
+    version: "7.0.1"
   yaml:
     dependency: "direct dev"
     description:
@@ -602,4 +586,4 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
+  dart: ">=3.11.0 <4.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -285,10 +285,10 @@ packages:
     dependency: "direct dev"
     description:
       name: lints
-      sha256: a5e2b223cb7c9c8efdc663ef484fdd95bb243bff242ef5b13e26883547fce9a0
+      sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.0"
+    version: "6.1.0"
   logging:
     dependency: "direct main"
     description:

--- a/test/browser_test.dart
+++ b/test/browser_test.dart
@@ -36,14 +36,10 @@ void main() {
   });
 
   group('Browser.target', () {
-    test(
-      'should return browser target',
-      () async {
-        var target = browser.target;
-        expect(target.type, 'browser');
-      },
-      skip: 'Investigate to use autoAttach and fix failure',
-    );
+    test('should return browser target', () async {
+      var target = browser.target;
+      expect(target.type, 'browser');
+    }, skip: 'Investigate to use autoAttach and fix failure');
   });
 
   group('Browser.process', () {

--- a/test/coverage_test.dart
+++ b/test/coverage_test.dart
@@ -129,17 +129,13 @@ void main() {
       );
     });
     group('resetOnNavigation', () {
-      test(
-        'should report scripts across navigations when disabled',
-        () async {
-          await page.coverage.startJSCoverage(resetOnNavigation: false);
-          await page.goto(server.prefix + '/jscoverage/multiple.html');
-          await page.goto(server.emptyPage);
-          var coverage = await page.coverage.stopJSCoverage();
-          expect(coverage.length, equals(2));
-        },
-        skip: 'Not working since v132',
-      );
+      test('should report scripts across navigations when disabled', () async {
+        await page.coverage.startJSCoverage(resetOnNavigation: false);
+        await page.goto(server.prefix + '/jscoverage/multiple.html');
+        await page.goto(server.emptyPage);
+        var coverage = await page.coverage.stopJSCoverage();
+        expect(coverage.length, equals(2));
+      }, skip: 'Not working since v132');
       test(
         'should NOT report scripts across navigations when enabled',
         () async {

--- a/test/downloader_concurrent_test.dart
+++ b/test/downloader_concurrent_test.dart
@@ -72,84 +72,80 @@ void main() {
       }
     });
 
-    test(
-      'cross-process concurrent download deduplicates',
-      () async {
-        final logDir = Directory(p.join(tmp.path, '_log'))..createSync();
-        final barrier = File(p.join(tmp.path, '_go'));
-        final workerScript = p.join(
-          Directory.current.path,
-          'test',
-          'utils',
-          'concurrent_download_worker.dart',
+    test('cross-process concurrent download deduplicates', () async {
+      final logDir = Directory(p.join(tmp.path, '_log'))..createSync();
+      final barrier = File(p.join(tmp.path, '_go'));
+      final workerScript = p.join(
+        Directory.current.path,
+        'test',
+        'utils',
+        'concurrent_download_worker.dart',
+      );
+
+      const workerCount = 4;
+      final processes = await Future.wait(
+        List.generate(
+          workerCount,
+          (i) => Process.start(Platform.executable, [
+            workerScript,
+            tmp.path,
+            logDir.path,
+            i.toString(),
+            barrier.path,
+          ]),
+        ),
+      );
+
+      // Wait until every worker reports "ready" before flipping the barrier,
+      // so they all hit ensureBrowserDownloaded near-simultaneously.
+      final outputs = List.generate(workerCount, (_) => StringBuffer());
+      final readyFutures = <Future<void>>[];
+      for (var i = 0; i < workerCount; i++) {
+        final lines = processes[i].stdout
+            .transform(const SystemEncoding().decoder)
+            .transform(const LineSplitter())
+            .asBroadcastStream();
+        final readyCompleter = Completer<void>();
+        lines.listen(
+          (line) {
+            if (line == 'ready' && !readyCompleter.isCompleted) {
+              readyCompleter.complete();
+            } else {
+              outputs[i].writeln(line);
+            }
+          },
+          onDone: () {
+            if (!readyCompleter.isCompleted) {
+              readyCompleter.complete();
+            }
+          },
         );
+        readyFutures.add(readyCompleter.future);
+      }
+      await Future.wait(readyFutures);
 
-        const workerCount = 4;
-        final processes = await Future.wait(
-          List.generate(
-            workerCount,
-            (i) => Process.start(Platform.executable, [
-              workerScript,
-              tmp.path,
-              logDir.path,
-              i.toString(),
-              barrier.path,
-            ]),
-          ),
-        );
+      barrier.writeAsStringSync('go');
 
-        // Wait until every worker reports "ready" before flipping the barrier,
-        // so they all hit ensureBrowserDownloaded near-simultaneously.
-        final outputs = List.generate(workerCount, (_) => StringBuffer());
-        final readyFutures = <Future<void>>[];
-        for (var i = 0; i < workerCount; i++) {
-          final lines = processes[i].stdout
-              .transform(const SystemEncoding().decoder)
-              .transform(const LineSplitter())
-              .asBroadcastStream();
-          final readyCompleter = Completer<void>();
-          lines.listen(
-            (line) {
-              if (line == 'ready' && !readyCompleter.isCompleted) {
-                readyCompleter.complete();
-              } else {
-                outputs[i].writeln(line);
-              }
-            },
-            onDone: () {
-              if (!readyCompleter.isCompleted) {
-                readyCompleter.complete();
-              }
-            },
-          );
-          readyFutures.add(readyCompleter.future);
-        }
-        await Future.wait(readyFutures);
+      final exitCodes = await Future.wait(processes.map((p) => p.exitCode));
+      for (var i = 0; i < workerCount; i++) {
+        expect(exitCodes[i], 0, reason: 'worker $i exited non-zero');
+      }
 
-        barrier.writeAsStringSync('go');
+      final downloadCount = logDir.listSync().length;
+      expect(
+        downloadCount,
+        1,
+        reason: 'Exactly one process should do the actual download',
+      );
 
-        final exitCodes = await Future.wait(processes.map((p) => p.exitCode));
-        for (var i = 0; i < workerCount; i++) {
-          expect(exitCodes[i], 0, reason: 'worker $i exited non-zero');
-        }
-
-        final downloadCount = logDir.listSync().length;
-        expect(
-          downloadCount,
-          1,
-          reason: 'Exactly one process should do the actual download',
-        );
-
-        final paths = outputs.map((b) => b.toString().trim()).toSet();
-        expect(
-          paths.length,
-          1,
-          reason: 'All workers should report the same path; got $paths',
-        );
-        expect(File(paths.single).existsSync(), isTrue);
-      },
-      timeout: const Timeout(Duration(seconds: 60)),
-    );
+      final paths = outputs.map((b) => b.toString().trim()).toSet();
+      expect(
+        paths.length,
+        1,
+        reason: 'All workers should report the same path; got $paths',
+      );
+      expect(File(paths.single).existsSync(), isTrue);
+    }, timeout: const Timeout(Duration(seconds: 60)));
 
     test(
       'atomic rename: <version> never visible until download completes',

--- a/test/emulation_test.dart
+++ b/test/emulation_test.dart
@@ -160,159 +160,151 @@ void main() {
   });
 
   group('Page.emulateMediaFeatures', () {
-    test(
-      'should work ddd',
-      () async {
-        await page.emulateMediaFeatures([
-          MediaFeature.prefersReducedMotion('reduce'),
-        ]);
-        expect(
-          await page.evaluate(
-            "() => matchMedia('(prefers-reduced-motion: reduce)').matches",
-          ),
-          isTrue,
-        );
-        expect(
-          await page.evaluate(
-            "() => matchMedia('(prefers-reduced-motion: no-preference)').matches",
-          ),
-          isFalse,
-        );
-        await page.emulateMediaFeatures([
-          MediaFeature.prefersColorsScheme('light'),
-        ]);
-        expect(
-          await page.evaluate(
-            "() => matchMedia('(prefers-color-scheme: light)').matches",
-          ),
-          isTrue,
-        );
-        expect(
-          await page.evaluate(
-            "() => matchMedia('(prefers-color-scheme: dark)').matches",
-          ),
-          isFalse,
-        );
-        expect(
-          await page.evaluate(
-            "() => matchMedia('(prefers-color-scheme: no-preference)').matches",
-          ),
-          isFalse,
-        );
-        await page.emulateMediaFeatures([
-          MediaFeature.prefersColorsScheme('dark'),
-        ]);
-        expect(
-          await page.evaluate(
-            "() => matchMedia('(prefers-color-scheme: dark)').matches",
-          ),
-          isTrue,
-        );
-        expect(
-          await page.evaluate(
-            "() => matchMedia('(prefers-color-scheme: light)').matches",
-          ),
-          isFalse,
-        );
-        expect(
-          await page.evaluate(
-            "() => matchMedia('(prefers-color-scheme: no-preference)').matches",
-          ),
-          isFalse,
-        );
-        await page.emulateMediaFeatures([
-          MediaFeature.prefersReducedMotion('reduce'),
-          MediaFeature.prefersColorsScheme('light'),
-        ]);
-        expect(
-          await page.evaluate(
-            "() => matchMedia('(prefers-reduced-motion: reduce)').matches",
-          ),
-          isTrue,
-        );
-        expect(
-          await page.evaluate(
-            "() => matchMedia('(prefers-reduced-motion: no-preference)').matches",
-          ),
-          isFalse,
-        );
-        expect(
-          await page.evaluate(
-            "() => matchMedia('(prefers-color-scheme: light)').matches",
-          ),
-          isTrue,
-        );
-        expect(
-          await page.evaluate(
-            "() => matchMedia('(prefers-color-scheme: dark)').matches",
-          ),
-          isFalse,
-        );
-        expect(
-          await page.evaluate(
-            "() => matchMedia('(prefers-color-scheme: no-preference)').matches",
-          ),
-          isFalse,
-        );
-      },
-      skip: 'This is not working in headless and flaky in headful',
-    );
+    test('should work ddd', () async {
+      await page.emulateMediaFeatures([
+        MediaFeature.prefersReducedMotion('reduce'),
+      ]);
+      expect(
+        await page.evaluate(
+          "() => matchMedia('(prefers-reduced-motion: reduce)').matches",
+        ),
+        isTrue,
+      );
+      expect(
+        await page.evaluate(
+          "() => matchMedia('(prefers-reduced-motion: no-preference)').matches",
+        ),
+        isFalse,
+      );
+      await page.emulateMediaFeatures([
+        MediaFeature.prefersColorsScheme('light'),
+      ]);
+      expect(
+        await page.evaluate(
+          "() => matchMedia('(prefers-color-scheme: light)').matches",
+        ),
+        isTrue,
+      );
+      expect(
+        await page.evaluate(
+          "() => matchMedia('(prefers-color-scheme: dark)').matches",
+        ),
+        isFalse,
+      );
+      expect(
+        await page.evaluate(
+          "() => matchMedia('(prefers-color-scheme: no-preference)').matches",
+        ),
+        isFalse,
+      );
+      await page.emulateMediaFeatures([
+        MediaFeature.prefersColorsScheme('dark'),
+      ]);
+      expect(
+        await page.evaluate(
+          "() => matchMedia('(prefers-color-scheme: dark)').matches",
+        ),
+        isTrue,
+      );
+      expect(
+        await page.evaluate(
+          "() => matchMedia('(prefers-color-scheme: light)').matches",
+        ),
+        isFalse,
+      );
+      expect(
+        await page.evaluate(
+          "() => matchMedia('(prefers-color-scheme: no-preference)').matches",
+        ),
+        isFalse,
+      );
+      await page.emulateMediaFeatures([
+        MediaFeature.prefersReducedMotion('reduce'),
+        MediaFeature.prefersColorsScheme('light'),
+      ]);
+      expect(
+        await page.evaluate(
+          "() => matchMedia('(prefers-reduced-motion: reduce)').matches",
+        ),
+        isTrue,
+      );
+      expect(
+        await page.evaluate(
+          "() => matchMedia('(prefers-reduced-motion: no-preference)').matches",
+        ),
+        isFalse,
+      );
+      expect(
+        await page.evaluate(
+          "() => matchMedia('(prefers-color-scheme: light)').matches",
+        ),
+        isTrue,
+      );
+      expect(
+        await page.evaluate(
+          "() => matchMedia('(prefers-color-scheme: dark)').matches",
+        ),
+        isFalse,
+      );
+      expect(
+        await page.evaluate(
+          "() => matchMedia('(prefers-color-scheme: no-preference)').matches",
+        ),
+        isFalse,
+      );
+    }, skip: 'This is not working in headless and flaky in headful');
 
-    test(
-      'should not interfer with emulateMediaType',
-      () async {
-        await page.emulateMediaType(MediaType.print);
-        expect(
-          await page.evaluate("() => window.matchMedia('screen').matches"),
-          isFalse,
-        );
-        await page.emulateMediaFeatures([
-          MediaFeature.prefersColorsScheme('dark'),
-        ]);
-        expect(
-          await page.evaluate(
-            "() => matchMedia('(prefers-color-scheme: dark)').matches",
-          ),
-          isTrue,
-        );
+    test('should not interfer with emulateMediaType', () async {
+      await page.emulateMediaType(MediaType.print);
+      expect(
+        await page.evaluate("() => window.matchMedia('screen').matches"),
+        isFalse,
+      );
+      await page.emulateMediaFeatures([
+        MediaFeature.prefersColorsScheme('dark'),
+      ]);
+      expect(
+        await page.evaluate(
+          "() => matchMedia('(prefers-color-scheme: dark)').matches",
+        ),
+        isTrue,
+      );
 
-        await page.emulateMediaFeatures(null);
-        expect(
-          await page.evaluate(
-            "() => matchMedia('(prefers-color-scheme: dark)').matches",
-          ),
-          isFalse,
-        );
-        expect(
-          await page.evaluate("() => window.matchMedia('screen').matches"),
-          isFalse,
-        );
+      await page.emulateMediaFeatures(null);
+      expect(
+        await page.evaluate(
+          "() => matchMedia('(prefers-color-scheme: dark)').matches",
+        ),
+        isFalse,
+      );
+      expect(
+        await page.evaluate("() => window.matchMedia('screen').matches"),
+        isFalse,
+      );
 
-        await page.emulateMediaType(null);
-        expect(
-          await page.evaluate("() => window.matchMedia('screen').matches"),
-          isTrue,
-        );
+      await page.emulateMediaType(null);
+      expect(
+        await page.evaluate("() => window.matchMedia('screen').matches"),
+        isTrue,
+      );
 
-        await page.emulateMediaFeatures([
-          MediaFeature.prefersColorsScheme('dark'),
-        ]);
-        expect(
-          await page.evaluate(
-            "() => matchMedia('(prefers-color-scheme: dark)').matches",
-          ),
-          isTrue,
-        );
-        await page.emulateMediaType(null);
-        expect(
-          await page.evaluate(
-            "() => matchMedia('(prefers-color-scheme: dark)').matches",
-          ),
-          isTrue,
-        );
-      },
-      skip: 'This is not working in headless and flaky in headful',
-    );
+      await page.emulateMediaFeatures([
+        MediaFeature.prefersColorsScheme('dark'),
+      ]);
+      expect(
+        await page.evaluate(
+          "() => matchMedia('(prefers-color-scheme: dark)').matches",
+        ),
+        isTrue,
+      );
+      await page.emulateMediaType(null);
+      expect(
+        await page.evaluate(
+          "() => matchMedia('(prefers-color-scheme: dark)').matches",
+        ),
+        isTrue,
+      );
+    }, skip: 'This is not working in headless and flaky in headful');
   });
 
   group('Page.emulateTimezone', () {

--- a/test/keyboard_test.dart
+++ b/test/keyboard_test.dart
@@ -33,7 +33,8 @@ void main() {
     expect(Key.allKeys['Control'], Key.control);
     expect(Key.allKeys['notexist'], isNull);
     expect(Key.allKeys[''], isNull);
-    expect(Key.allKeys[null], isNull);
+    String? nullKey;
+    expect(Key.allKeys[nullKey], isNull);
 
     for (var key in Key.allKeys.values) {
       expect(key.toString(), isNotNull);

--- a/test/launcher_test.dart
+++ b/test/launcher_test.dart
@@ -213,17 +213,13 @@ void main() {
           contains('--user-data-dir=${Uri.base.resolve('foo').toFilePath()}'),
         );
       });
-      test(
-        'should work with no default arguments',
-        () async {
-          var browser = await puppeteer.launch(ignoreDefaultArgs: true);
-          var page = await browser.newPage();
-          expect(await page.evaluate('11 * 11'), 121);
-          await page.close();
-          await browser.close();
-        },
-        skip: 'manual test, it launches a browser headful',
-      );
+      test('should work with no default arguments', () async {
+        var browser = await puppeteer.launch(ignoreDefaultArgs: true);
+        var page = await browser.newPage();
+        expect(await page.evaluate('11 * 11'), 121);
+        await page.close();
+        await browser.close();
+      }, skip: 'manual test, it launches a browser headful');
       test('should filter out ignored default arguments', () async {
         //TODO(xha): implement the feature and find a way to test it;
       });

--- a/test/navigation_test.dart
+++ b/test/navigation_test.dart
@@ -108,29 +108,21 @@ void main() {
         ),
       );
     });
-    test(
-      'should fail when navigating to bad SSL',
-      () async {
-        // Make sure that network events do not emit 'undefined'.
-        // @see https://crbug.com/750469
-        page.onRequest.listen((request) => expect(request, isNotNull));
-        page.onRequestFinished.listen((request) => expect(request, isNotNull));
-        page.onRequestFailed.listen((request) => expect(request, isNotNull));
+    test('should fail when navigating to bad SSL', () async {
+      // Make sure that network events do not emit 'undefined'.
+      // @see https://crbug.com/750469
+      page.onRequest.listen((request) => expect(request, isNotNull));
+      page.onRequestFinished.listen((request) => expect(request, isNotNull));
+      page.onRequestFailed.listen((request) => expect(request, isNotNull));
 
-        //expect(() => page.goto(httpsServer.emptyPage), throwsA(predicate((e) => '$e'.contains('net::ERR_CERT_AUTHORITY_INVALID'))));
-      },
-      skip: "Test server doesn't support https yet",
-    );
-    test(
-      'should fail when navigating to bad SSL after redirects',
-      () async {
-        server.setRedirect('/redirect/1.html', '/redirect/2.html');
-        server.setRedirect('/redirect/2.html', '/empty.html');
+      //expect(() => page.goto(httpsServer.emptyPage), throwsA(predicate((e) => '$e'.contains('net::ERR_CERT_AUTHORITY_INVALID'))));
+    }, skip: "Test server doesn't support https yet");
+    test('should fail when navigating to bad SSL after redirects', () async {
+      server.setRedirect('/redirect/1.html', '/redirect/2.html');
+      server.setRedirect('/redirect/2.html', '/empty.html');
 
-        //expect(() => page.goto(httpsServer.prefix + '/redirect/1.html'), throwsA(predicate((e) => '$e'.contains('net::ERR_CERT_AUTHORITY_INVALID'))));
-      },
-      skip: "Test server doesn't support https yet",
-    );
+      //expect(() => page.goto(httpsServer.prefix + '/redirect/1.html'), throwsA(predicate((e) => '$e'.contains('net::ERR_CERT_AUTHORITY_INVALID'))));
+    }, skip: "Test server doesn't support https yet");
     test('should fail when main resources failed to load', () async {
       expect(
         () => page.goto('http://localhost:44123/non-existing-url'),

--- a/test/network_test.dart
+++ b/test/network_test.dart
@@ -204,17 +204,13 @@ void main() {
       var response = await page.goto(server.prefix + '/simple.json');
       expect(await response.text, startsWith('{"foo": "bar"}'));
     });
-    test(
-      'should return uncompressed text',
-      () async {
-        //TODO(xha): add feature to server and enable test
-        //server.enableGzip('/simple.json');
-        var response = await page.goto(server.prefix + '/simple.json');
-        expect(response.headers['content-encoding'], equals('gzip'));
-        expect(await response.text, equals('{"foo": "bar"}\n'));
-      },
-      skip: "Test server doesn't have enableGzip",
-    );
+    test('should return uncompressed text', () async {
+      //TODO(xha): add feature to server and enable test
+      //server.enableGzip('/simple.json');
+      var response = await page.goto(server.prefix + '/simple.json');
+      expect(response.headers['content-encoding'], equals('gzip'));
+      expect(await response.text, equals('{"foo": "bar"}\n'));
+    }, skip: "Test server doesn't have enableGzip");
     test('should throw when requesting body of redirected response', () async {
       server.setRedirect('/foo.html', '/empty.html');
       var response = await page.goto(server.prefix + '/foo.html');

--- a/tool/code_style/fix_import_order.dart
+++ b/tool/code_style/fix_import_order.dart
@@ -5,6 +5,7 @@ import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:dart_style/dart_style.dart';
 import 'dart_project.dart';
+import 'language_version.dart';
 
 void main() {
   for (var project in getSubOrContainingProjects(Directory.current.path)) {
@@ -32,11 +33,11 @@ bool fixFile(DartFile dartFile) {
 }
 
 final DartFormatter _dartFormatter = DartFormatter(
-  languageVersion: DartFormatter.latestLanguageVersion,
+  languageVersion: packageLanguageVersion,
 );
 
 final analyzerFeatureSet = FeatureSet.fromEnableFlags2(
-  sdkLanguageVersion: DartFormatter.latestLanguageVersion,
+  sdkLanguageVersion: packageLanguageVersion,
   flags: ['inline-class'],
 );
 

--- a/tool/code_style/fix_import_order.dart
+++ b/tool/code_style/fix_import_order.dart
@@ -4,7 +4,6 @@ import 'package:analyzer/dart/analysis/features.dart';
 import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:dart_style/dart_style.dart';
-import 'package:pub_semver/pub_semver.dart' show Version;
 import 'dart_project.dart';
 
 void main() {
@@ -37,7 +36,7 @@ final DartFormatter _dartFormatter = DartFormatter(
 );
 
 final analyzerFeatureSet = FeatureSet.fromEnableFlags2(
-  sdkLanguageVersion: Version(3, 3, 0),
+  sdkLanguageVersion: DartFormatter.latestLanguageVersion,
   flags: ['inline-class'],
 );
 

--- a/tool/code_style/language_version.dart
+++ b/tool/code_style/language_version.dart
@@ -1,0 +1,20 @@
+import 'dart:io';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:yaml/yaml.dart';
+
+/// The language version of this package, the one `dart format` derives from the
+/// `sdk` constraint in pubspec.yaml.
+///
+/// The generators run `package:dart_style` themselves, so they must format at
+/// that same version. `DartFormatter.latestLanguageVersion` follows the
+/// dart_style release instead, and a newer language version is formatted
+/// differently — the generated code would no longer agree with `dart format`.
+final Version packageLanguageVersion = _readPackageLanguageVersion();
+
+Version _readPackageLanguageVersion() {
+  var pubspec = loadYaml(File('pubspec.yaml').readAsStringSync()) as YamlMap;
+  var sdkConstraint = (pubspec['environment'] as YamlMap)['sdk'] as String;
+  var minimum = (VersionConstraint.parse(sdkConstraint) as VersionRange).min!;
+
+  return Version(minimum.major, minimum.minor, 0);
+}

--- a/tool/generate_api_doc.dart
+++ b/tool/generate_api_doc.dart
@@ -107,12 +107,12 @@ class Class {
 
   static Class fromDeclaration(ClassDeclaration declaration) {
     var clas = Class(
-      declaration.name.toString(),
+      declaration.namePart.typeName.toString(),
       readComment(declaration.documentationComment),
     );
 
     clas.methods.addAll(
-      declaration.members
+      declaration.body.members
           .where((member) => member.documentationComment != null)
           .map((member) => Method.fromClassMember(clas, member))
           .nonNulls,

--- a/tool/generate_devices.dart
+++ b/tool/generate_devices.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'package:dart_style/dart_style.dart';
 import 'package:json_annotation/json_annotation.dart';
+import 'code_style/language_version.dart';
 import 'utils/split_words.dart';
 import 'utils/string_helpers.dart';
 
@@ -52,7 +53,7 @@ void main() async {
   buffer.writeln('final devices = Devices._();');
   File('lib/src/devices.dart').writeAsStringSync(
     DartFormatter(
-      languageVersion: DartFormatter.latestLanguageVersion,
+      languageVersion: packageLanguageVersion,
     ).format(buffer.toString()),
   );
 }

--- a/tool/generate_protocol.dart
+++ b/tool/generate_protocol.dart
@@ -310,9 +310,17 @@ class _Command {
             "'${parameter.name}' : ${_toJsonCode(parameter, needsExplicitToJson: false, isLocalVariable: true)},";
       }
       for (var parameter in optionals) {
-        sendCode += 'if (${parameter.normalizedName} != null)';
-        sendCode +=
-            "'${parameter.name}' : ${_toJsonCode(parameter, needsExplicitToJson: false, isLocalVariable: true)},";
+        var jsonCode = _toJsonCode(
+          parameter,
+          needsExplicitToJson: false,
+          isLocalVariable: true,
+        );
+        if (jsonCode == parameter.normalizedName) {
+          sendCode += "'${parameter.name}' : ?$jsonCode,";
+        } else {
+          sendCode += 'if (${parameter.normalizedName} != null)';
+          sendCode += "'${parameter.name}' : $jsonCode,";
+        }
       }
 
       sendCode += '}';

--- a/tool/generate_readme.dart
+++ b/tool/generate_readme.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'package:dart_style/dart_style.dart';
+import 'code_style/language_version.dart';
 import 'download_protocol_from_repo.dart' show protocols;
 
 final RegExp _importRegex = RegExp(r"import '([^']+)';\r?\n");
@@ -9,7 +10,7 @@ final RegExp _ignoreForFileRegex = RegExp(
 );
 
 final DartFormatter _dartFormatter = DartFormatter(
-  languageVersion: DartFormatter.latestLanguageVersion,
+  languageVersion: packageLanguageVersion,
   lineEnding: Platform.isWindows ? '\r\n' : '\n',
 );
 

--- a/tool/generate_test_all_file.dart
+++ b/tool/generate_test_all_file.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'package:dart_style/dart_style.dart';
 import 'package:path/path.dart' as p;
+import 'code_style/language_version.dart';
 
 void main() {
   var allFiles = Directory('test')
@@ -27,7 +28,7 @@ void main() {
 
   File('test/test_all.dart').writeAsStringSync(
     DartFormatter(
-      languageVersion: DartFormatter.latestLanguageVersion,
+      languageVersion: packageLanguageVersion,
     ).format(buffer.toString()),
   );
 }

--- a/tool/inject_examples_to_doc.dart
+++ b/tool/inject_examples_to_doc.dart
@@ -6,6 +6,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:dart_style/dart_style.dart';
+import 'code_style/language_version.dart';
 
 // Extrat the samples from the file test/doc_examples_test.dart and inject
 // it in the source code
@@ -34,18 +35,16 @@ void main() {
   }
 }
 
-final _formatter = DartFormatter(
-  languageVersion: DartFormatter.latestLanguageVersion,
-);
+final _formatter = DartFormatter(languageVersion: packageLanguageVersion);
 
 String replaceExamples(String sourceFile, List<CodeSnippet> snippets) {
   var unit = parseString(content: sourceFile).unit;
 
   for (var aClass
       in unit.declarations.whereType<ClassDeclaration>().toList().reversed) {
-    var className = aClass.name.toString();
+    var className = aClass.namePart.typeName.toString();
 
-    for (var member in aClass.members.reversed) {
+    for (var member in aClass.body.members.reversed) {
       var comment = member.documentationComment;
 
       if (comment != null) {


### PR DESCRIPTION
Stacked on #491 (base is `fix-dart-3-13-analyzer-warnings`, so CI here is green; GitHub will retarget to `master` once that merges).

pub.dev scored static analysis 40/50 — 150 points overall — on 541 `use_null_aware_elements` infos. `lints` 6.1.0 added that rule to `recommended.yaml`, but the committed `pubspec.lock` still pinned 6.0.0, so neither CI nor a local `dart analyze` ever saw it; pub.dev resolves the newest versions instead.

**1. Generate null-aware elements.** All 546 sites are generated code — the optional parameters of each CDP command are emitted as `if (x != null) 'x': x`. This emits `'x': ?x` instead, which is exactly equivalent (the entry is dropped when the value is null):

```dart
-    await _client.send('WebAuthn.enable', {
-      if (enableUI != null) 'enableUI': enableUI,
-    });
+    await _client.send('WebAuthn.enable', {'enableUI': ?enableUI});
```

Only sites whose JSON expression is the bare variable are rewritten. The `toJson()` bodies build their map from non-promotable public fields, which the rule does not flag, so they keep the `if` form. `fix_import_order.dart` parsed generated code with a feature set pinned to language version 3.3, which cannot parse null-aware elements — it now tracks the package's language version.

**2. `dart pub upgrade` before the pana check**, so the job resolves what pub.dev resolves. Without it the check can report 160/160 while the published score drops, which is exactly how this regression went unnoticed.

**3. Upgrade the dependencies** so the checked-in lock matches. Two adjustments were needed:
- analyzer 14 removed `ClassDeclaration.name` and `.members`; the doc generators use `namePart.typeName` and `body.members`.
- the generators formatted with `DartFormatter.latestLanguageVersion`, which dart_style 3.1.12 reports as 3.13, while `dart format` formats at the package's own language version (3.9, from the sdk constraint). The two disagree, so every generated file drifted by a blank line or a reflow. They now share a `packageLanguageVersion` read from pubspec.yaml.

### Verification

`dart tool/check_pana.dart` under Dart 3.13 (what CI installs for `stable`) → **160/160**. `dart analyze --fatal-infos .` clean under 3.12.2 and 3.13, `dart tool/generate_protocol.dart` + `dart tool/prepare_submit.dart` are a fixed point, and the navigation / network / emulation / page / frame / browser / coverage tests pass.

### One caveat worth knowing before publishing

dart_style changed layout between the SDK bundled in Dart 3.12 and the one in 3.13, and `lib/protocol/bluetooth_emulation.dart` lands on the difference (the null-aware rewrite shortens the map enough for the newer formatter to prefer a chain). No formatting satisfies both — verified by formatting the file with each SDK. This branch matches Dart 3.13, so CI is 160/160, but pub.dev is currently analysing with Dart 3.12.2 and would score the formatting 40/50 — the same 150 points as today, just for a different reason — until pub.dev moves to 3.13. Publishing after that happens avoids the dip entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)