### PR TITLE
Release 3.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.26.0
+- Update to Chrome 152.0.7977.42.
+
 ## 3.25.1
 - Complete WASM compatibility: route `dart:isolate` through the same shim.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: puppeteer
 description: A high-level API to control headless Chrome over the DevTools Protocol. This is a port of Puppeteer in Dart.
-version: 3.25.1
+version: 3.26.0
 homepage: https://github.com/xvrh/puppeteer-dart
 
 funding:


### PR DESCRIPTION
Version bump and changelog entry for everything on `master` since 3.25.1: the Chrome 152 roll (#493) and the analyzer/lint fixes (#491, #492).

Minor rather than patch because the Chrome roll changes the generated protocol surface — the same call made for 3.22.0 and 3.23.0.

`dart tool/check_pana.dart` under Dart 3.13 → 160/160, which also covers pana's changelog check for the new version.

Publishing is triggered by pushing a `v3.26.0` tag, so merging this does not release. Worth recalling the timing note from #492: pub.dev still analyses with Dart 3.12.2, whose formatter disagrees with 3.13's on `lib/protocol/bluetooth_emulation.dart`, so publishing before pub.dev moves to 3.13 would score 40/50 on static analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)